### PR TITLE
Update for websocket 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ path = "src/lib.rs"
 [dependencies]
 hyper = "*"
 rustc-serialize = "*"
-websocket = "0.9.7"
+websocket = "0.10.0"


### PR DESCRIPTION
This updates the library to work with websocket 0.10.0.

The biggest change is passing (tx, rx) Messages instead of Strings to allow Client.split() usage without having to use an `Arc<Mutex<Client>>`.