### PR TITLE
Use rustc_serialize instead of "rustc-serialize"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ limitations under the License.
 extern crate hyper;
 extern crate websocket;
 extern crate openssl;
-extern crate "rustc-serialize" as rustc_serialize;
+extern crate rustc_serialize;
 
 use rustc_serialize::json::{Json};
 use std::sync::mpsc::{Sender,Receiver,channel};


### PR DESCRIPTION
extern expects a identifier directly instead of string now