### PR TITLE
Moved errors into their own module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,77 @@
+use std::fmt;
+use std::io;
+
+use hyper;
+use websocket;
+use url;
+use rustc_serialize;
+
+/// slack::Error represents errors that can happen while using the RtmClient
+#[derive(Debug)]
+pub enum Error {
+    /// Http client error
+    Http(hyper::Error),
+    /// WebSocket connection error
+    WebSocket(websocket::result::WebSocketError),
+    /// Error parsing url
+    Url(url::ParseError),
+    /// Error decoding Json
+    JsonDecode(rustc_serialize::json::DecoderError),
+    /// Error encoding Json
+    JsonEncode(rustc_serialize::json::EncoderError),
+    /// Slack Api Error
+    Api(String),
+    /// Errors that do not fit under the other types, Internal is for EG channel errors.
+    Internal(String)
+}
+
+impl From<hyper::Error> for Error {
+    fn from(err: hyper::Error) -> Error {
+        Error::Http(err)
+    }
+}
+
+impl From<websocket::result::WebSocketError> for Error {
+    fn from(err: websocket::result::WebSocketError) -> Error {
+        Error::WebSocket(err)
+    }
+}
+
+impl From<url::ParseError> for Error {
+    fn from(err: url::ParseError) -> Error {
+        Error::Url(err)
+    }
+}
+
+impl From<rustc_serialize::json::DecoderError> for Error {
+    fn from(err: rustc_serialize::json::DecoderError) -> Error {
+        Error::JsonDecode(err)
+    }
+}
+
+impl From<rustc_serialize::json::EncoderError> for Error {
+    fn from(err: rustc_serialize::json::EncoderError) -> Error {
+        Error::JsonEncode(err)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::Internal(format!("{:?}", err))
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s = match *self {
+            Error::Http(ref e) => format!("Http (hyper) Error: {:?}", e),
+            Error::WebSocket(ref e) => format!("Http (hyper) Error: {:?}", e),
+            Error::Url(ref e) => format!("Url Error: {:?}", e),
+            Error::JsonDecode(ref e) => format!("Json Decode Error: {:?}", e),
+            Error::JsonEncode(ref e) => format!("Json Encode Error: {:?}", e),
+            Error::Api(ref st) => format!("Slack Api Error: {:?}", st),
+            Error::Internal(ref st) => format!("Internal Error: {:?}", st)
+        };
+        f.write_str(&s)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,9 @@ extern crate openssl;
 extern crate rustc_serialize;
 extern crate url;
 
+pub mod error;
+use error::Error;
+
 use std::sync::mpsc::{Sender,Receiver,channel};
 use std::thread;
 use std::io::Read;
@@ -77,78 +80,6 @@ use websocket::stream::WebSocketStream;
 pub type WsClient = Client<websocket::dataframe::DataFrame,
                            websocket::client::sender::Sender<websocket::stream::WebSocketStream>,
                            websocket::client::receiver::Receiver<websocket::stream::WebSocketStream>>;
-
-/// slack::Error represents errors that can happen while using the RtmClient
-#[derive(Debug)]
-pub enum Error {
-    /// Http client error
-    Http(hyper::Error),
-    /// WebSocket connection error
-    WebSocket(websocket::result::WebSocketError),
-    /// Error parsing url
-    Url(url::ParseError),
-    /// Error decoding Json
-    JsonDecode(rustc_serialize::json::DecoderError),
-    /// Error encoding Json
-    JsonEncode(rustc_serialize::json::EncoderError),
-    /// Slack Api Error
-    Api(String),
-    /// Errors that do not fit under the other types, Internal is for EG channel errors.
-    Internal(String)
-}
-
-impl From<hyper::Error> for Error {
-    fn from(err: hyper::Error) -> Error {
-        Error::Http(err)
-    }
-}
-
-impl From<websocket::result::WebSocketError> for Error {
-    fn from(err: websocket::result::WebSocketError) -> Error {
-        Error::WebSocket(err)
-    }
-}
-
-impl From<url::ParseError> for Error {
-    fn from(err: url::ParseError) -> Error {
-        Error::Url(err)
-    }
-}
-
-impl From<rustc_serialize::json::DecoderError> for Error {
-    fn from(err: rustc_serialize::json::DecoderError) -> Error {
-        Error::JsonDecode(err)
-    }
-}
-
-impl From<rustc_serialize::json::EncoderError> for Error {
-    fn from(err: rustc_serialize::json::EncoderError) -> Error {
-        Error::JsonEncode(err)
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Error {
-        Error::Internal(format!("{:?}", err))
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let s = match *self {
-            Error::Http(ref e) => format!("Http (hyper) Error: {:?}", e),
-            Error::WebSocket(ref e) => format!("Http (hyper) Error: {:?}", e),
-            Error::Url(ref e) => format!("Url Error: {:?}", e),
-            Error::JsonDecode(ref e) => format!("Json Decode Error: {:?}", e),
-            Error::JsonEncode(ref e) => format!("Json Encode Error: {:?}", e),
-            Error::Api(ref st) => format!("Slack Api Error: {:?}", st),
-            Error::Internal(ref st) => format!("Internal Error: {:?}", st)
-        };
-        f.write_str(&s)
-    }
-}
-
-
 
 /// Implement this trait in your code to handle message events
 pub trait EventHandler {


### PR DESCRIPTION
Nice work with adding the errors! I think it would be wise to move them into their own module though to prevent `lib.rs` from growing even larger.

**Note** that I made the `Error` type the public export instead of the module to prevent this from being a breaking change. However I would suggest having the module publicly exported instead to follow the convention of other libraries like [`hyper`](http://hyper.rs/hyper/hyper/error/index.html) and [`rust-postgres`](https://github.com/sfackler/rust-postgres/blob/master/src/lib.rs#L94).