### PR TITLE
Web API wrapper modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ hyper = "~0.6.14"
 openssl = "^0.6.4"
 rustc-serialize = "^0.3"
 url = "^0.2"
+
+[dev-dependencies]
+yup-hyper-mock = "*"
+log = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 name = "slack"
 version = "0.9.2"
-authors = ["Benjamin Elder <ben.the.elder@gmail.com>"]
+authors = ["Benjamin Elder <ben.the.elder@gmail.com>", "Matt Jones <mthjones@gmail.com>"]
 repository = "https://github.com/BenTheElder/slack-rs.git"
 documentation = "https://bentheelder.github.io/slack-rs"
 description = "slack realtime messaging client: https://api.slack.com/bot-users"

--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -1,0 +1,68 @@
+//! Checks API calling code.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Checks API calling code.
+///
+/// Wraps https://api.slack.com/methods/api.test
+pub fn test(client: &hyper::Client, token: &str, args: Option<HashMap<&str, &str>>, error: Option<&str>) -> ApiResult<ApiTestResponse> {
+    let mut params = HashMap::new();
+    if let Some(error) = error {
+        params.insert("error", error);
+    }
+    if let Some(args) = args {
+        params.extend(args);
+    }
+    make_authed_api_call(client, "api.test", token, params)
+}
+
+#[derive(RustcDecodable)]
+pub struct ApiTestResponse {
+    pub error: Option<String>,
+    pub args: Option<HashMap<String, String>>
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = test(&client, "TEST_TOKEN", None, Some("some_error"));
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockTestOkResponder,
+        r#"{
+            "ok": true,
+            "args": {
+                "arg1": "val1",
+                "arg2": "val2"
+            }
+        }"#
+    );
+
+    #[test]
+    fn test_ok_response() {
+        let client = hyper::Client::with_connector(MockTestOkResponder::default());
+        let mut args = HashMap::new();
+        args.insert("arg1", "val1");
+        args.insert("arg2", "val2");
+        let result = test(&client, "TEST_TOKEN", Some(args), None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().args.unwrap().get("arg1").unwrap(), "val1");
+    }
+}

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1,0 +1,61 @@
+//! Checks authentication & identity.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Checks authentication & identity.
+///
+/// Wraps https://api.slack.com/methods/auth.test
+pub fn test(client: &hyper::Client, token: &str) -> ApiResult<TestResponse> {
+    make_authed_api_call(client, "auth.test", token, HashMap::new())
+}
+
+#[derive(RustcDecodable)]
+pub struct TestResponse {
+    pub url: String,
+    pub team: String,
+    pub user: String,
+    pub team_id: String,
+    pub user_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = test(&client, "TEST_TOKEN");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockTestOkResponder,
+        r#"{
+            "ok": true,
+            "url": "https:\/\/example-team.slack.com\/",
+            "team": "example team",
+            "user": "testuser",
+            "team_id": "T12345678",
+            "user_id": "U12345678"
+        }"#
+    );
+
+    #[test]
+    fn test_ok_response() {
+        let client = hyper::Client::with_connector(MockTestOkResponder::default());
+        let result = test(&client, "TEST_TOKEN");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().user, "testuser");
+    }
+}

--- a/src/api/channels.rs
+++ b/src/api/channels.rs
@@ -1,0 +1,641 @@
+//! Get info on your team's Slack channels, create or archive channels, invite users, set the topic
+//! and purpose, and mark a channel as read.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Archives a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.archive
+pub fn archive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<ArchiveResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "channels.archive", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ArchiveResponse;
+
+/// Creates a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.create
+pub fn create(client: &hyper::Client, token: &str, name: &str) -> ApiResult<CreateResponse> {
+    let mut params = HashMap::new();
+    params.insert("name", name);
+    make_authed_api_call(client, "channels.create", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct CreateResponse {
+    pub channel: super::Channel,
+}
+
+/// Fetches history of messages and events from a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.history
+pub fn history(client: &hyper::Client, token: &str, channel: &str, latest: Option<&str>, oldest: Option<&str>, inclusive: Option<bool>, count: Option<u32>) -> ApiResult<HistoryResponse> {
+    let count = count.map(|c| c.to_string());
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    if let Some(latest) = latest {
+        params.insert("latest", latest);
+    }
+    if let Some(oldest) = oldest {
+        params.insert("oldest", oldest);
+    }
+    if let Some(inclusive) = inclusive {
+        params.insert("inclusive", if inclusive { "1" } else { "0" });
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    make_authed_api_call(client, "channels.history", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct HistoryResponse {
+    pub latest: Option<String>,
+    pub oldest: Option<String>,
+    pub messages: Vec<super::MessageEvent>,
+    pub has_more: bool,
+}
+
+/// Gets information about a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.info
+pub fn info(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<InfoResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "channels.info", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct InfoResponse {
+    channel: super::Channel,
+}
+
+/// Invites a user to a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.invite
+pub fn invite(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<InviteResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("user", user);
+    make_authed_api_call(client, "channels.invite", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct InviteResponse {
+    channel: super::Channel,
+}
+
+/// Joins a channel, creating it if needed.
+///
+/// Wraps https://api.slack.com/methods/channels.join
+pub fn join(client: &hyper::Client, token: &str, name: &str) -> ApiResult<JoinResponse> {
+    let mut params = HashMap::new();
+    params.insert("name", name);
+    make_authed_api_call(client, "channels.join", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct JoinResponse {
+    already_in_channel: Option<bool>,
+    channel: super::Channel,
+}
+
+/// Removes a user from a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.kick
+pub fn kick(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<KickResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("user", user);
+    make_authed_api_call(client, "channels.kick", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct KickResponse;
+
+/// Leaves a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.leave
+pub fn leave(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<LeaveResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "channels.leave", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct LeaveResponse {
+    pub not_in_channel: Option<bool>,
+}
+
+/// Lists all channels in a Slack team.
+///
+/// Wraps https://api.slack.com/methods/channels.list
+pub fn list(client: &hyper::Client, token: &str, exclude_archived: Option<bool>) -> ApiResult<ListResponse> {
+    let mut params = HashMap::new();
+    if let Some(exclude_archived) = exclude_archived {
+        params.insert("exclude_archived", if exclude_archived { "1" } else { "0" });
+    }
+    make_authed_api_call(client, "channels.list", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub channels: Vec<super::Channel>,
+}
+
+/// Sets the read cursor in a channel.
+///
+/// https://api.slack.com/methods/channels.mark
+pub fn mark(client: &hyper::Client, token: &str, channel: &str, ts: &str) -> ApiResult<MarkResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("ts", ts);
+    make_authed_api_call(client, "channels.mark", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct MarkResponse;
+
+/// Renames a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.rename
+pub fn rename(client: &hyper::Client, token: &str, channel: &str, name: &str) -> ApiResult<RenameResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("name", name);
+    make_authed_api_call(client, "channels.rename", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AbridgedChannel {
+    pub id: String,
+    pub is_channel: bool,
+    pub name: String,
+    pub created: i32,
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct RenameResponse {
+    pub channel: AbridgedChannel,
+}
+
+/// Sets the purpose for a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.setPurpose
+pub fn set_purpose(client: &hyper::Client, token: &str, channel: &str, purpose: &str) -> ApiResult<SetPurposeResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("purpose", purpose);
+    make_authed_api_call(client, "channels.setPurpose", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SetPurposeResponse {
+    pub purpose: String,
+}
+
+/// Sets the topic for a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.setTopic
+pub fn set_topic(client: &hyper::Client, token: &str, channel: &str, topic: &str) -> ApiResult<SetTopicResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("topic", topic);
+    make_authed_api_call(client, "channels.setTopic", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SetTopicResponse {
+    pub topic: String,
+}
+
+/// Unarchives a channel.
+///
+/// Wraps https://api.slack.com/methods/channels.unarchive
+pub fn unarchive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<UnarchiveResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "channels.unarchive", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct UnarchiveResponse;
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+    use super::super::MessageEvent;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = info(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockArchiveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn archive_ok_response() {
+        let client = hyper::Client::with_connector(MockArchiveOkResponder::default());
+        let result = archive(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockCreateOkResponder,
+        r#"{
+            "ok": true,
+            "channel": {
+                "id": "C024BE91L",
+                "name": "testing",
+                "is_channel": true,
+                "created": 1444102158,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_general": false,
+                "is_member": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                },
+                "purpose": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn create_ok_response() {
+        let client = hyper::Client::with_connector(MockCreateOkResponder::default());
+        let result = create(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().channel.id == "C024BE91L");
+    }
+
+    mock_slack_responder!(MockHistoryOkResponder,
+        r#"{
+            "ok": true,
+            "messages": [
+                {
+                    "type": "message",
+                    "user": "U024BE7LH",
+                    "text": "lol",
+                    "ts": "1444078138.000084"
+                },
+                {
+                    "type": "message",
+                    "user": "U024BE7LH",
+                    "text": "Hello world",
+                    "ts": "1444078079.000083"
+                }
+            ],
+            "has_more": true
+        }"#
+    );
+
+    #[test]
+    fn history_ok_response() {
+        let client = hyper::Client::with_connector(MockHistoryOkResponder::default());
+        let result = history(&client, "TEST_TOKEN", "TEST_CHANNEL", None, None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().messages[0].clone() {
+            MessageEvent::Standard { ts: _, channel: _, user: _, text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                assert_eq!(text.unwrap(), "lol");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        }
+    }
+
+    mock_slack_responder!(MockInfoOkResponder,
+        r#"{
+            "ok": true,
+            "channel": {
+                "id": "C024BE91L",
+                "name": "testing",
+                "is_channel": true,
+                "created": 1444102158,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_general": false,
+                "is_member": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                },
+                "purpose": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn info_ok_response() {
+        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
+        let result = info(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().channel.id == "C024BE91L");
+    }
+
+    mock_slack_responder!(MockInviteOkResponder,
+        r#"{
+            "ok": true,
+            "channel": {
+                "id": "C024BE91L",
+                "name": "testing",
+                "is_channel": true,
+                "created": 1444102158,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_general": false,
+                "is_member": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                },
+                "purpose": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn invite_ok_response() {
+        let client = hyper::Client::with_connector(MockInviteOkResponder::default());
+        let result = invite(&client, "TEST_TOKEN", "TEST_CHANNEL", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().channel.id == "C024BE91L");
+    }
+
+    mock_slack_responder!(MockJoinOkResponder,
+        r#"{
+            "ok": true,
+            "channel": {
+                "id": "C024BE91L",
+                "name": "testing",
+                "is_channel": true,
+                "created": 1444102158,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_general": false,
+                "is_member": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                },
+                "purpose": {
+                    "value": "",
+                    "creator": "",
+                    "last_set": 0
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn join_ok_response() {
+        let client = hyper::Client::with_connector(MockJoinOkResponder::default());
+        let result = join(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().channel.id == "C024BE91L");
+    }
+
+    mock_slack_responder!(MockKickOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn kick_ok_response() {
+        let client = hyper::Client::with_connector(MockKickOkResponder::default());
+        let result = kick(&client, "TEST_TOKEN", "TEST_CHANNEL", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockLeaveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn leave_ok_response() {
+        let client = hyper::Client::with_connector(MockLeaveOkResponder::default());
+        let result = leave(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockListOkResponder,
+        r#"{
+            "ok": true,
+            "channels": [
+                {
+                    "id": "C024BE91L",
+                    "name": "testing",
+                    "is_channel": true,
+                    "created": 1444102158,
+                    "creator": "U024BE7LH",
+                    "is_archived": false,
+                    "is_general": false,
+                    "is_member": true,
+                    "last_read": "0000000000.000000",
+                    "latest": null,
+                    "unread_count": 0,
+                    "unread_count_display": 0,
+                    "members": [
+                        "U024BE7LH"
+                    ],
+                    "topic": {
+                        "value": "",
+                        "creator": "",
+                        "last_set": 0
+                    },
+                    "purpose": {
+                        "value": "",
+                        "creator": "",
+                        "last_set": 0
+                    }
+                },
+                {
+                    "id": "C024BE91J",
+                    "name": "testing",
+                    "is_channel": true,
+                    "created": 1444102158,
+                    "creator": "U024BE7LH",
+                    "is_archived": false,
+                    "is_general": false,
+                    "is_member": true,
+                    "last_read": "0000000000.000000",
+                    "latest": null,
+                    "unread_count": 0,
+                    "unread_count_display": 0,
+                    "members": [
+                        "U024BE7LH"
+                    ],
+                    "topic": {
+                        "value": "",
+                        "creator": "",
+                        "last_set": 0
+                    },
+                    "purpose": {
+                        "value": "",
+                        "creator": "",
+                        "last_set": 0
+                    }
+                }
+            ]
+        }"#
+    );
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN", None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().channels[1].id == "C024BE91J");
+    }
+
+    mock_slack_responder!(MockMarkOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn mark_ok_response() {
+        let client = hyper::Client::with_connector(MockMarkOkResponder::default());
+        let result = mark(&client, "TEST_TOKEN", "TEST_CHANNEL", "1234567890.123456");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockRenameOkResponder,
+        r#"{
+            "ok": true,
+            "channel": {
+                "id": "C024BE91J",
+                "is_channel": true,
+                "name": "NEW_NAME",
+                "created": 1444102158
+            }
+        }"#
+    );
+
+    #[test]
+    fn rename_ok_response() {
+        let client = hyper::Client::with_connector(MockRenameOkResponder::default());
+        let result = rename(&client, "TEST_TOKEN", "TEST_CHANNEL", "newname");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().channel.name == "NEW_NAME")
+    }
+
+    mock_slack_responder!(MockSetPurposeOkResponder,
+        r#"{
+            "ok": true,
+            "purpose": "This is the new purpose!"
+        }"#
+    );
+
+    #[test]
+    fn set_purpose_ok_response() {
+        let client = hyper::Client::with_connector(MockSetPurposeOkResponder::default());
+        let result = set_purpose(&client, "TEST_TOKEN", "TEST_CHANNEL", "This is the new purpose!");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().purpose == "This is the new purpose!")
+    }
+
+    mock_slack_responder!(MockSetTopicOkResponder,
+        r#"{
+            "ok": true,
+            "topic": "This is the new topic!"
+        }"#
+    );
+
+    #[test]
+    fn set_topic_ok_response() {
+        let client = hyper::Client::with_connector(MockSetTopicOkResponder::default());
+        let result = set_topic(&client,
+                               "TEST_TOKEN",
+                               "TEST_CHANNEL",
+                               "This is the new topic!");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().topic == "This is the new topic!")
+    }
+
+    mock_slack_responder!(MockUnarchiveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn unarchive_ok_response() {
+        let client = hyper::Client::with_connector(MockUnarchiveOkResponder::default());
+        let result = unarchive(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+}

--- a/src/api/chat.rs
+++ b/src/api/chat.rs
@@ -1,0 +1,198 @@
+//! Post chat messages to Slack.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Deletes a message.
+///
+/// Wraps https://api.slack.com/methods/chat.delete
+pub fn delete(client: &hyper::Client, token: &str, ts: &str, channel: &str) -> ApiResult<DeleteResponse> {
+    let mut params = HashMap::new();
+    params.insert("ts", ts);
+    params.insert("channel", channel);
+    make_authed_api_call(client, "chat.delete", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct DeleteResponse {
+    pub channel: String,
+    pub ts: String,
+}
+
+/// Sends a message to a channel.
+///
+/// Wraps https://api.slack.com/methods/chat.postMessage
+pub fn post_message(client: &hyper::Client, token: &str, channel: &str, text: &str, username: Option<&str>, as_user: Option<bool>, parse: Option<&str>, link_names: Option<bool>, attachments: Option<&str>, unfurl_links: Option<bool>, unfurl_media: Option<bool>, icon_url: Option<&str>, icon_emoji: Option<&str>) -> ApiResult<PostMessageResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("text", text);
+    if let Some(username) = username {
+        params.insert("username", username);
+    }
+    if let Some(as_user) = as_user {
+        params.insert("as_user", if as_user { "true" } else { "false" });
+    }
+    if let Some(parse) = parse {
+        params.insert("parse", parse);
+    }
+    if let Some(link_names) = link_names {
+        params.insert("link_names", if link_names { "1" } else { "0" });
+    }
+    if let Some(attachments) = attachments {
+        params.insert("attachments", attachments);
+    }
+    if let Some(unfurl_links) = unfurl_links {
+        params.insert("unfurl_links", if unfurl_links { "true" } else { "false" });
+    }
+    if let Some(unfurl_media) = unfurl_media {
+        params.insert("unfurl_media", if unfurl_media { "true" } else { "false" });
+    }
+    if let Some(icon_url) = icon_url {
+        params.insert("icon_url", icon_url);
+    }
+    if let Some(icon_emoji) = icon_emoji {
+        params.insert("icon_emoji", icon_emoji);
+    }
+    make_authed_api_call(client, "chat.postMessage", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct PostMessageResponse {
+    pub ts: String,
+    pub channel: String,
+    pub message: super::MessageEvent,
+}
+
+/// Updates a message.
+///
+/// Wraps https://api.slack.com/methods/chat.update
+pub fn update(client: &hyper::Client, token: &str, ts: &str, channel: &str, text: &str, attachments: Option<&str>, parse: Option<&str>, link_names: Option<bool>) -> ApiResult<UpdateResponse> {
+    let mut params = HashMap::new();
+    params.insert("ts", ts);
+    params.insert("channel", channel);
+    params.insert("text", text);
+    if let Some(attachments) = attachments {
+        params.insert("attachments", attachments);
+    }
+    if let Some(parse) = parse {
+        params.insert("parse", parse);
+    }
+    if let Some(link_names) = link_names {
+        params.insert("link_names", if link_names { "1" } else { "0" });
+    }
+    make_authed_api_call(client, "chat.update", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct UpdateResponse {
+    pub channel: String,
+    pub ts: String,
+    pub text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+    use super::super::MessageEvent;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = post_message(&client, "TEST_TOKEN", "TEST_CHANNEL", "Test message", None, None, None, None, None, None, None, None, None);
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockDeleteResponder, r#"{
+        "ok": true,
+        "channel": "C024BE91L",
+        "ts": "1401383885.000061"
+    }"#);
+
+    #[test]
+    fn delete_ok_response() {
+        let client = hyper::Client::with_connector(MockDeleteResponder::default());
+        let result = delete(&client, "TEST_TOKEN", "TEST_CHANNEL", "1401383885.000061");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().ts, "1401383885.000061");
+    }
+
+    mock_slack_responder!(MockPostMessageResponder, r#"{
+        "ok": true,
+        "ts": "1405895017.000506",
+        "channel": "C024BE91L",
+        "message": {
+            "type": "message",
+            "user": "U024BE7LH",
+            "text": "Test message",
+            "ts": "1444078138.000084"
+        }
+    }"#);
+
+    #[test]
+    fn post_message_ok_response() {
+        let client = hyper::Client::with_connector(MockPostMessageResponder::default());
+        let result = post_message(&client, "TEST_TOKEN", "TEST_CHANNEL", "Test message", None, Some(true), None, None, None, None, None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().message {
+            MessageEvent::Standard { ts: _, channel: _, user: _, text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                assert_eq!(text.unwrap(), "Test message");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        }
+    }
+
+    mock_slack_responder!(MockBotPostMessageResponder, r#"{
+        "ok": true,
+        "ts": "1405895017.000506",
+        "channel": "C024BE91L",
+        "message": {
+            "type": "message",
+            "text": "Test message",
+            "ts": "1444078138.000084"
+        }
+    }"#);
+
+    #[test]
+    fn bot_post_message_ok_response() {
+        let client = hyper::Client::with_connector(MockPostMessageResponder::default());
+        let result = post_message(&client, "TEST_TOKEN", "TEST_CHANNEL", "Test message", None, None, None, None, None, None, None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().message.clone() {
+            MessageEvent::Standard { ts: _, channel: _, user: _, text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                assert_eq!(text.unwrap(), "Test message")
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        }
+    }
+
+    mock_slack_responder!(MockUpdateResponder, r#"{
+        "ok": true,
+        "channel": "C024BE91L",
+        "ts": "1401383885.000061",
+        "text": "Test message"
+    }"#);
+
+    #[test]
+    fn update_ok_response() {
+        let client = hyper::Client::with_connector(MockUpdateResponder::default());
+        let result = update(&client, "TEST_TOKEN", "TEST_CHANNEL", "1401383885.000061", "Test message", None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().text, "Test message");
+    }
+}

--- a/src/api/emoji.rs
+++ b/src/api/emoji.rs
@@ -1,0 +1,55 @@
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Lists custom emoji for a team.
+///
+/// Wraps https://api.slack.com/methods/emoji.list
+pub fn list(client: &hyper::Client, token: &str) -> ApiResult<ListResponse> {
+    make_authed_api_call(client, "emoji.list", token, HashMap::new())
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub emoji: HashMap<String, String>
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = list(&client, "TEST_TOKEN");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockListOkResponder,
+        r#"{
+            "ok": true,
+            "emoji": {
+                "bowtie": "https:\/\/my.slack.com\/emoji\/bowtie\/46ec6f2bb0.png",
+                "squirrel": "https:\/\/my.slack.com\/emoji\/squirrel\/f35f40c0e0.png",
+                "shipit": "alias:squirrel"
+            }
+        }"#
+    );
+
+    #[test]
+    fn test_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().emoji.get("shipit").unwrap(), "alias:squirrel");
+    }
+}

--- a/src/api/files.rs
+++ b/src/api/files.rs
@@ -1,0 +1,319 @@
+//! Get info on files uploaded to Slack, upload new files to Slack.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Deletes a file.
+///
+/// Wraps https://api.slack.com/methods/files.delete
+pub fn delete(client: &hyper::Client, token: &str, file: &str) -> ApiResult<DeleteResponse> {
+    let mut params = HashMap::new();
+    params.insert("file", file);
+    make_authed_api_call(client, "files.delete", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct DeleteResponse;
+
+/// Gets information about a team file.
+///
+/// Wraps https://api.slack.com/methods/files.info
+pub fn info(client: &hyper::Client, token: &str, file: &str, count: Option<u32>, page: Option<u32>) -> ApiResult<InfoResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params = HashMap::new();
+    params.insert("file", file);
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "files.info", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct InfoResponse {
+    pub file: super::File,
+    pub comments: Vec<super::Comment>,
+    pub paging: super::Pagination
+}
+
+/// Lists & filters team files.
+///
+/// Wraps https://api.slack.com/methods/files.list
+pub fn list(client: &hyper::Client, token: &str, user: Option<&str>, ts_from: Option<&str>, ts_to: Option<&str>, types: Option<&str>, count: Option<u32>, page: Option<u32>) -> ApiResult<ListResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params = HashMap::new();
+    if let Some(user) = user {
+        params.insert("user", user);
+    }
+    if let Some(ts_from) = ts_from {
+        params.insert("ts_from", ts_from);
+    }
+    if let Some(ts_to) = ts_to {
+        params.insert("ts_to", ts_to);
+    }
+    if let Some(types) = types {
+        params.insert("types", types);
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "files.list", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub files: Vec<super::File>,
+    pub paging: super::Pagination
+}
+
+// /// Uploads or creates a file.
+// ///
+// /// Wraps https://api.slack.com/methods/files.upload
+// #[allow(unused_variables)]
+// pub fn upload(client: &hyper::Client, token: &str, file: Option<Vec<u8>>, content: Option<&str>, filetype: Option<&str>, filename: Option<&str>, title: Option<&str>, initial_comment: Option<&str>, channels: Option<&str>) -> ApiResult<UploadResponse> {
+//     Err(::error::Error::Api(String::from("Currently unsupported.")))
+// }
+//
+// #[derive(Clone,Debug,RustcDecodable)]
+// pub struct UploadResponse {
+//     pub file: super::File
+// }
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = delete(&client, "TEST_TOKEN", "F12345678");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockDeleteOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn delete_ok_response() {
+        let client = hyper::Client::with_connector(MockDeleteOkResponder::default());
+        let result = delete(&client, "TEST_TOKEN", "F12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockInfoOkResponder, r#"{
+        "ok": true,
+        "file": {
+            "id" : "F2147483862",
+            "timestamp" : 1356032811,
+
+            "name" : "file.htm",
+            "title" : "My HTML file",
+            "mimetype" : "text\/plain",
+            "filetype" : "text",
+            "pretty_type": "Text",
+            "user" : "U2147483697",
+
+            "mode" : "hosted",
+            "editable" : true,
+            "is_external": false,
+            "external_type": "",
+
+            "size" : 12345,
+
+            "url": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/1.png",
+            "url_download": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/download\/1.png",
+            "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+            "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+            "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+            "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+            "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+            "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+            "thumb_360_w": 100,
+            "thumb_360_h": 100,
+
+            "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+            "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+            "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+            "preview_highlight" : "&lt;div class=\"sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+            "lines" : 123,
+            "lines_more": 118,
+
+            "is_public": true,
+            "public_url_shared": false,
+            "channels": ["C024BE7LT"],
+            "groups": ["G12345"],
+            "initial_comment": {
+                "id": "Fc027BN9L9",
+                "timestamp": 1356032811,
+                "user": "U2147483697",
+                "comment": "This is a comment"
+            },
+            "num_stars": 7,
+            "is_starred": true
+        },
+        "comments": [
+            {
+                "id": "Fc027BN9L9",
+                "timestamp": 1356032811,
+                "user": "U2147483697",
+                "comment": "This is a comment"
+            }
+        ],
+        "paging": {
+            "count": 100,
+            "total": 2,
+            "page": 1,
+            "pages": 0
+        }
+    }"#);
+
+    #[test]
+    fn info_ok_response() {
+        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
+        let result = info(&client, "TEST_TOKEN", "F12345678", None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().file.id, "F2147483862");
+    }
+
+    mock_slack_responder!(MockListOkResponder, r#"{
+        "ok": true,
+        "files": [
+            {
+                "id" : "F2147483862",
+                "timestamp" : 1356032811,
+
+                "name" : "file.htm",
+                "title" : "My HTML file",
+                "mimetype" : "text\/plain",
+                "filetype" : "text",
+                "pretty_type": "Text",
+                "user" : "U2147483697",
+
+                "mode" : "hosted",
+                "editable" : true,
+                "is_external": false,
+                "external_type": "",
+
+                "size" : 12345,
+
+                "url": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/1.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/download\/1.png",
+                "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+                "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+                "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+                "thumb_360_w": 100,
+                "thumb_360_h": 100,
+
+                "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+                "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+                "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+                "preview_highlight" : "&lt;div class=\"sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+                "lines" : 123,
+                "lines_more": 118,
+
+                "is_public": true,
+                "public_url_shared": false,
+                "channels": ["C024BE7LT"],
+                "groups": ["G12345"],
+                "initial_comment": {
+                    "id": "Fc027BN9L9",
+                    "timestamp": 1356032811,
+                    "user": "U2147483697",
+                    "comment": "This is a comment"
+                },
+                "num_stars": 7,
+                "is_starred": true
+            },
+            {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            }
+        ],
+        "paging": {
+            "count": 100,
+            "total": 295,
+            "page": 1,
+            "pages": 3
+        }
+    }"#);
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN", None, None, None, None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().files[0].id, "F2147483862");
+    }
+}

--- a/src/api/groups.rs
+++ b/src/api/groups.rs
@@ -1,0 +1,739 @@
+//! Get info on your team's private groups.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Archives a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.archive
+pub fn archive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<ArchiveResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "groups.archive", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ArchiveResponse;
+
+/// Closes a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.close
+pub fn close(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<CloseResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "groups.close", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct CloseResponse {
+    pub no_op: Option<bool>,
+    pub already_closed: Option<bool>
+}
+
+/// Creates a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.create
+pub fn create(client: &hyper::Client, token: &str, name: &str) -> ApiResult<CreateResponse> {
+    let mut params = HashMap::new();
+    params.insert("name", name);
+    make_authed_api_call(client, "groups.create", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct CreateResponse {
+    pub group: super::Group
+}
+
+/// Clones and archives a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.createChild
+pub fn create_child(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<CreateChildResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "groups.createChild", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct CreateChildResponse {
+    pub group: super::Group
+}
+
+/// Fetches history of messages and events from a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.history
+pub fn history(client: &hyper::Client, token: &str, channel: &str, latest: Option<&str>, oldest: Option<&str>, inclusive: Option<bool>, count: Option<u32>) -> ApiResult<HistoryResponse> {
+    let count = count.map(|c| c.to_string());
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    if let Some(latest) = latest {
+        params.insert("latest", latest);
+    }
+    if let Some(oldest) = oldest {
+        params.insert("oldest", oldest);
+    }
+    if let Some(inclusive) = inclusive {
+        params.insert("inclusive", if inclusive { "1" } else { "0" });
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    make_authed_api_call(client, "groups.history", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct HistoryResponse {
+    pub latest: Option<String>,
+    pub oldest: Option<String>,
+    pub messages: Vec<super::MessageEvent>,
+    pub has_more: bool,
+    pub is_limited: Option<bool>
+}
+
+/// Gets information about a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.info
+pub fn info(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<InfoResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "groups.info", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct InfoResponse {
+    pub group: super::Group
+}
+
+/// Invites a user to a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.invite
+pub fn invite(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<InviteResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("user", user);
+    make_authed_api_call(client, "groups.invite", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct InviteResponse {
+    pub group: super::Group,
+    pub already_in_group: Option<bool>
+}
+
+/// Removes a user from a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.kick
+pub fn kick(client: &hyper::Client, token: &str, channel: &str, user: &str) -> ApiResult<KickResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("user", user);
+    make_authed_api_call(client, "groups.kick", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct KickResponse;
+
+/// Leaves a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.leave
+pub fn leave(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<LeaveResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "groups.leave", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct LeaveResponse;
+
+/// Lists private groups that the calling user has access to.
+///
+/// Wraps https://api.slack.com/methods/groups.list
+pub fn list(client: &hyper::Client, token: &str, exclude_archived: Option<bool>) -> ApiResult<ListResponse> {
+    let mut params = HashMap::new();
+    if let Some(exclude_archived) = exclude_archived {
+        params.insert("exclude_archived", if exclude_archived { "1" } else { "0" });
+    }
+    make_authed_api_call(client, "groups.list", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub groups: Vec<super::Group>
+}
+
+/// Sets the read cursor in a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.mark
+pub fn mark(client: &hyper::Client, token: &str, channel: &str, ts: &str) -> ApiResult<MarkResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("ts", ts);
+    make_authed_api_call(client, "groups.mark", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct MarkResponse;
+
+/// Opens a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.open
+pub fn open(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<OpenResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "groups.open", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct OpenResponse {
+    pub no_op: Option<bool>,
+    pub already_open: Option<bool>
+}
+
+/// Renames a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.rename
+pub fn rename(client: &hyper::Client, token: &str, channel: &str, name: &str) -> ApiResult<RenameResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("name", name);
+    make_authed_api_call(client, "groups.rename", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AbridgedGroup {
+    pub id: String,
+    pub is_group: bool,
+    pub name: String,
+    pub created: i32,
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct RenameResponse {
+    pub channel: AbridgedGroup
+}
+
+/// Sets the purpose for a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.setPurpose
+pub fn set_purpose(client: &hyper::Client, token: &str, channel: &str, purpose: &str) -> ApiResult<SetPurposeResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("purpose", purpose);
+    make_authed_api_call(client, "groups.setPurpose", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SetPurposeResponse {
+    pub purpose: String
+}
+
+/// Sets the topic for a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.setTopic
+pub fn set_topic(client: &hyper::Client, token: &str, channel: &str, topic: &str) -> ApiResult<SetTopicResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    params.insert("topic", topic);
+    make_authed_api_call(client, "groups.setTopic", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SetTopicResponse {
+    pub topic: String
+}
+
+/// Unarchives a private group.
+///
+/// Wraps https://api.slack.com/methods/groups.unarchive
+pub fn unarchive(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<UnarchiveResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "groups.unarchive", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct UnarchiveResponse;
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+    use super::super::MessageEvent;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = info(&client, "TEST_TOKEN", "G12345678");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockArchiveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn archive_ok_response() {
+        let client = hyper::Client::with_connector(MockArchiveOkResponder::default());
+        let result = archive(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockCloseOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn close_ok_response() {
+        let client = hyper::Client::with_connector(MockCloseOkResponder::default());
+        let result = close(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockCloseAlreadyClosedOkResponder,
+        r#"{
+            "ok": true,
+            "no_op": true,
+            "already_closed": true
+        }"#
+    );
+
+    #[test]
+    fn close_already_closed_ok_response() {
+        let client = hyper::Client::with_connector(MockCloseAlreadyClosedOkResponder::default());
+        let result = close(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().already_closed.unwrap(), true);
+    }
+
+    mock_slack_responder!(MockCreateOkResponder,
+        r#"{
+            "ok": true,
+            "group": {
+                "id": "G12345678",
+                "name": "secretplans",
+                "is_group": true,
+                "created": 1360782804,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_open": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "Secret plans on hold",
+                    "creator": "U024BE7LV",
+                    "last_set": 1369677212
+                },
+                "purpose": {
+                    "value": "Discuss secret plans that no-one else should know",
+                    "creator": "U024BE7LH",
+                    "last_set": 1360782804
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn create_ok_response() {
+        let client = hyper::Client::with_connector(MockCreateOkResponder::default());
+        let result = create(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().group.id == "G12345678");
+    }
+
+    mock_slack_responder!(MockCreateChildOkResponder,
+        r#"{
+            "ok": true,
+            "group": {
+                "id": "G12345678",
+                "name": "secretplans",
+                "is_group": true,
+                "created": 1360782804,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_open": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "Secret plans on hold",
+                    "creator": "U024BE7LV",
+                    "last_set": 1369677212
+                },
+                "purpose": {
+                    "value": "Discuss secret plans that no-one else should know",
+                    "creator": "U024BE7LH",
+                    "last_set": 1360782804
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn create_child_ok_response() {
+        let client = hyper::Client::with_connector(MockCreateChildOkResponder::default());
+        let result = create_child(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().group.id == "G12345678");
+    }
+
+    mock_slack_responder!(MockHistoryOkResponder,
+        r#"{
+            "ok": true,
+            "latest": "1358547726.000003",
+            "messages": [
+                {
+                    "type": "message",
+                    "ts": "1358546515.000008",
+                    "user": "U2147483896",
+                    "text": "Hello"
+                },
+                {
+                    "type": "message",
+                    "ts": "1358546515.000007",
+                    "user": "U2147483896",
+                    "text": "World",
+                    "is_starred": true
+                },
+                {
+                    "type": "something_else",
+                    "ts": "1358546515.000007",
+                    "wibblr": true
+                }
+            ],
+            "has_more": false
+        }"#
+    );
+
+    #[test]
+    fn history_ok_response() {
+        let client = hyper::Client::with_connector(MockHistoryOkResponder::default());
+        let result = history(&client, "TEST_TOKEN", "G12345678", None, None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().messages[0].clone() {
+            MessageEvent::Standard { ts: _, channel: _, user: _, text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                assert_eq!(text.unwrap(), "Hello")
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        }
+    }
+
+    mock_slack_responder!(MockInfoOkResponder,
+        r#"{
+            "ok": true,
+            "group": {
+                "id": "G12345678",
+                "name": "secretplans",
+                "is_group": true,
+                "created": 1360782804,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_open": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "Secret plans on hold",
+                    "creator": "U024BE7LV",
+                    "last_set": 1369677212
+                },
+                "purpose": {
+                    "value": "Discuss secret plans that no-one else should know",
+                    "creator": "U024BE7LH",
+                    "last_set": 1360782804
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn info_ok_response() {
+        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
+        let result = info(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().group.id == "G12345678");
+    }
+
+    mock_slack_responder!(MockInviteOkResponder,
+        r#"{
+            "ok": true,
+            "group": {
+                "id": "G12345678",
+                "name": "secretplans",
+                "is_group": true,
+                "created": 1360782804,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_open": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "Secret plans on hold",
+                    "creator": "U024BE7LV",
+                    "last_set": 1369677212
+                },
+                "purpose": {
+                    "value": "Discuss secret plans that no-one else should know",
+                    "creator": "U024BE7LH",
+                    "last_set": 1360782804
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn invite_ok_response() {
+        let client = hyper::Client::with_connector(MockInviteOkResponder::default());
+        let result = invite(&client, "TEST_TOKEN", "G12345678", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().group.id == "G12345678");
+    }
+
+    mock_slack_responder!(MockInviteAlreadyInGroupOkResponder,
+        r#"{
+            "ok": true,
+            "already_in_group": true,
+            "group": {
+                "id": "G12345678",
+                "name": "secretplans",
+                "is_group": true,
+                "created": 1360782804,
+                "creator": "U024BE7LH",
+                "is_archived": false,
+                "is_open": true,
+                "last_read": "0000000000.000000",
+                "latest": null,
+                "unread_count": 0,
+                "unread_count_display": 0,
+                "members": [
+                    "U024BE7LH"
+                ],
+                "topic": {
+                    "value": "Secret plans on hold",
+                    "creator": "U024BE7LV",
+                    "last_set": 1369677212
+                },
+                "purpose": {
+                    "value": "Discuss secret plans that no-one else should know",
+                    "creator": "U024BE7LH",
+                    "last_set": 1360782804
+                }
+            }
+        }"#
+    );
+
+    #[test]
+    fn invite_already_in_channel_ok_response() {
+        let client = hyper::Client::with_connector(MockInviteAlreadyInGroupOkResponder::default());
+        let result = invite(&client, "TEST_TOKEN", "G12345678", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().already_in_group.unwrap() == true);
+    }
+
+    mock_slack_responder!(MockKickOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn kick_ok_response() {
+        let client = hyper::Client::with_connector(MockKickOkResponder::default());
+        let result = kick(&client, "TEST_TOKEN", "G12345678", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockLeaveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn leave_ok_response() {
+        let client = hyper::Client::with_connector(MockLeaveOkResponder::default());
+        let result = leave(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockListOkResponder,
+        r#"{
+            "ok": true,
+            "groups": [
+                {
+                    "id": "G12345678",
+                    "name": "secretplans",
+                    "is_group": true,
+                    "created": 1360782804,
+                    "creator": "U024BE7LH",
+                    "is_archived": false,
+                    "is_open": true,
+                    "last_read": "0000000000.000000",
+                    "latest": null,
+                    "unread_count": 0,
+                    "unread_count_display": 0,
+                    "members": [
+                        "U024BE7LH"
+                    ],
+                    "topic": {
+                        "value": "Secret plans on hold",
+                        "creator": "U024BE7LV",
+                        "last_set": 1369677212
+                    },
+                    "purpose": {
+                        "value": "Discuss secret plans that no-one else should know",
+                        "creator": "U024BE7LH",
+                        "last_set": 1360782804
+                    }
+                },
+                {
+                    "id": "G87654321",
+                    "name": "secretplans",
+                    "is_group": true,
+                    "created": 1360782804,
+                    "creator": "U024BE7LH",
+                    "is_archived": false,
+                    "is_open": true,
+                    "last_read": "0000000000.000000",
+                    "latest": null,
+                    "unread_count": 0,
+                    "unread_count_display": 0,
+                    "members": [
+                        "U024BE7LH"
+                    ],
+                    "topic": {
+                        "value": "Secret plans on hold",
+                        "creator": "U024BE7LV",
+                        "last_set": 1369677212
+                    },
+                    "purpose": {
+                        "value": "Discuss secret plans that no-one else should know",
+                        "creator": "U024BE7LH",
+                        "last_set": 1360782804
+                    }
+                }
+            ]
+        }"#
+    );
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN", None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().groups[1].id == "G87654321");
+    }
+
+    mock_slack_responder!(MockMarkOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn mark_ok_response() {
+        let client = hyper::Client::with_connector(MockMarkOkResponder::default());
+        let result = mark(&client, "TEST_TOKEN", "G12345678", "1234567890.123456");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockRenameOkResponder,
+        r#"{
+            "ok": true,
+            "channel": {
+                "id": "C024BE91J",
+                "is_group": true,
+                "name": "NEW_NAME",
+                "created": 1444102158
+            }
+        }"#
+    );
+
+    #[test]
+    fn rename_ok_response() {
+        let client = hyper::Client::with_connector(MockRenameOkResponder::default());
+        let result = rename(&client, "TEST_TOKEN", "G12345678", "newname");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().channel.name == "NEW_NAME")
+    }
+
+    mock_slack_responder!(MockSetPurposeOkResponder,
+        r#"{
+            "ok": true,
+            "purpose": "This is the new purpose!"
+        }"#
+    );
+
+    #[test]
+    fn set_purpose_ok_response() {
+        let client = hyper::Client::with_connector(MockSetPurposeOkResponder::default());
+        let result = set_purpose(&client, "TEST_TOKEN", "G12345678", "This is the new purpose!");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().purpose == "This is the new purpose!")
+    }
+
+    mock_slack_responder!(MockSetTopicOkResponder,
+        r#"{
+            "ok": true,
+            "topic": "This is the new topic!"
+        }"#
+    );
+
+    #[test]
+    fn set_topic_ok_response() {
+        let client = hyper::Client::with_connector(MockSetTopicOkResponder::default());
+        let result = set_topic(&client, "TEST_TOKEN", "G12345678", "This is the new topic!");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().topic == "This is the new topic!")
+    }
+
+    mock_slack_responder!(MockUnarchiveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn unarchive_ok_response() {
+        let client = hyper::Client::with_connector(MockUnarchiveOkResponder::default());
+        let result = unarchive(&client, "TEST_TOKEN", "G12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+}

--- a/src/api/im.rs
+++ b/src/api/im.rs
@@ -1,0 +1,272 @@
+//! Get info on your direct messages.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Close a direct message channel.
+///
+/// Wraps https://api.slack.com/methods/im.close
+pub fn close(client: &hyper::Client, token: &str, channel_id: &str) -> ApiResult<CloseResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel_id);
+    make_authed_api_call(client, "im.close", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct CloseResponse {
+    pub no_op: Option<bool>,
+    pub already_closed: Option<bool>,
+}
+
+/// Fetches history of messages and events from direct message channel.
+///
+/// Wraps https://api.slack.com/methods/im.history
+pub fn history(client: &hyper::Client, token: &str, channel_id: &str, latest: Option<&str>, oldest: Option<&str>, inclusive: Option<bool>, count: Option<u32>) -> ApiResult<HistoryResponse> {
+    let count = count.map(|c| c.to_string());
+    let mut params = HashMap::new();
+    params.insert("channel", channel_id);
+    if let Some(latest) = latest {
+        params.insert("latest", latest);
+    }
+    if let Some(oldest) = oldest {
+        params.insert("oldest", oldest);
+    }
+    if let Some(inclusive) = inclusive {
+        params.insert("inclusive", if inclusive { "1" } else { "0" });
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    make_authed_api_call(client, "im.history", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct HistoryResponse {
+    pub latest: String,
+    pub messages: Vec<super::MessageEvent>,
+    pub has_more: bool,
+}
+
+/// Lists direct message channels for the calling user.
+///
+/// Wraps https://api.slack.com/methods/im.list
+pub fn list(client: &hyper::Client, token: &str) -> ApiResult<ListResponse> {
+    make_authed_api_call(client, "im.list", token, HashMap::new())
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub ims: Vec<super::Im>,
+}
+
+/// Sets the read cursor in a direct message channel.
+///
+/// Wraps https://api.slack.com/methods/im.mark
+pub fn mark(client: &hyper::Client, token: &str, channel_id: &str, timestamp: &str) -> ApiResult<MarkResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel_id);
+    params.insert("timestamp", timestamp);
+    make_authed_api_call(client, "im.mark", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct MarkResponse;
+
+/// Opens a direct message channel.
+///
+/// Wraps https://api.slack.com/methods/im.open
+pub fn open(client: &hyper::Client, token: &str, user_id: &str) -> ApiResult<OpenResponse> {
+    let mut params = HashMap::new();
+    params.insert("user", user_id);
+    make_authed_api_call(client, "im.open", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ChannelId {
+    pub id: String
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct OpenResponse {
+    pub no_op: Option<bool>,
+    pub already_open: Option<bool>,
+    pub channel: ChannelId,
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+    use super::super::MessageEvent;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = close(&client, "TEST_TOKEN", "D12345678");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockCloseOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn close_ok_response() {
+        let client = hyper::Client::with_connector(MockCloseOkResponder::default());
+        let result = close(&client, "TEST_TOKEN", "D12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockCloseAlreadyClosedOkResponder,
+        r#"{
+            "ok": true,
+            "no_op": true,
+            "already_closed": true
+        }"#
+    );
+
+    #[test]
+    fn close_already_closed_ok_response() {
+        let client = hyper::Client::with_connector(MockCloseAlreadyClosedOkResponder::default());
+        let result = close(&client, "TEST_TOKEN", "D12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().already_closed.unwrap(), true);
+    }
+
+    mock_slack_responder!(MockHistoryOkResponder,
+        r#"{
+            "ok": true,
+            "latest": "1358547726.000003",
+            "messages": [
+                {
+                    "type": "message",
+                    "ts": "1358546515.000008",
+                    "user": "U2147483896",
+                    "text": "Hello"
+                },
+                {
+                    "type": "message",
+                    "ts": "1358546515.000007",
+                    "user": "U2147483896",
+                    "text": "World",
+                    "is_starred": true
+                },
+                {
+                    "type": "something_else",
+                    "ts": "1358546515.000007",
+                    "wibblr": true
+                }
+            ],
+            "has_more": false
+        }"#
+    );
+
+    #[test]
+    fn history_ok_response() {
+        let client = hyper::Client::with_connector(MockHistoryOkResponder::default());
+        let result = history(&client, "TEST_TOKEN", "D12345678", None, None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().messages[0].clone() {
+            MessageEvent::Standard { ts: _, channel: _, user: _, text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                assert_eq!(text.unwrap(), "Hello");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        }
+    }
+
+    mock_slack_responder!(MockListOkResponder,
+        r#"{
+            "ok": true,
+            "ims": [
+                {
+                   "id": "D024BFF1M",
+                   "is_im": true,
+                   "user": "USLACKBOT",
+                   "created": 1372105335,
+                   "is_user_deleted": false
+                },
+                {
+                   "id": "D024BE7RE",
+                   "is_im": true,
+                   "user": "U024BE7LH",
+                   "created": 1356250715,
+                   "is_user_deleted": false
+                }
+            ]
+        }"#
+    );
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert!(result.unwrap().ims[1].id == "D024BE7RE");
+    }
+
+    mock_slack_responder!(MockMarkOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn mark_ok_response() {
+        let client = hyper::Client::with_connector(MockMarkOkResponder::default());
+        let result = mark(&client, "TEST_TOKEN", "D12345678", "1234567890.123456");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockOpenOkResponder,
+        r#"{
+            "ok": true,
+            "channel": {
+                "id": "D024BFF1M"
+            }
+        }"#
+    );
+
+    #[test]
+    fn open_ok_response() {
+        let client = hyper::Client::with_connector(MockOpenOkResponder::default());
+        let result = open(&client, "TEST_TOKEN", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().channel.id, "D024BFF1M");
+    }
+
+    mock_slack_responder!(MockOpenAlreadyOpenOkResponder,
+        r#"{
+            "ok": true,
+            "no_op": true,
+            "already_open": true,
+            "channel": {
+                "id": "D024BFF1M"
+            }
+        }"#
+    );
+
+    #[test]
+    fn open_already_open_ok_response() {
+        let client = hyper::Client::with_connector(MockOpenAlreadyOpenOkResponder::default());
+        let result = open(&client, "TEST_TOKEN", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.channel.id, "D024BFF1M");
+        assert_eq!(result.already_open.unwrap(), true);
+    }
+}

--- a/src/api/message_events.rs
+++ b/src/api/message_events.rs
@@ -1,0 +1,1241 @@
+use rustc_serialize::{Decodable,Decoder};
+
+use std::collections::HashMap;
+
+/// The metadata of an edited [`Message`](https://api.slack.com/events/message).
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct EditedMessageData {
+    pub user: String,
+    pub ts: String
+}
+
+/// Represents Slack [message event](https://api.slack.com/events/message) types.
+#[derive(Clone,Debug)]
+pub enum MessageEvent {
+    /// The Slack [`Message`](https://api.slack.com/events/message) event that represents a message
+    /// to a channel, group or im.
+    Standard {
+        ts: String,
+        channel: Option<String>,
+        user: Option<String>,
+        text: Option<String>,
+        is_starred: Option<bool>,
+        pinned_to: Option<Vec<String>>,
+        reactions: Option<Vec<super::Reaction>>,
+        edited: Option<EditedMessageData>,
+        attachments: Option<Vec<super::Attachment>>
+    },
+    /// Wraps the [`bot_message`](https://api.slack.com/events/message/bot_message) message event.
+    BotMessage {
+        ts: String,
+        text: String,
+        bot_id: String,
+        username: Option<String>,
+        icons: Option<HashMap<String,String>>
+    },
+    /// Wraps the [`me_message`](https://api.slack.com/events/message/me_message) message event.
+    MeMessage {
+        channel: String,
+        user: String,
+        text: String,
+        ts: String
+    },
+    /// Wraps the [`message_changed`](https://api.slack.com/events/message/message_changed) message
+    /// event.
+    MessageChanged {
+        hidden: bool,
+        channel: String,
+        ts: String,
+        message: Box<MessageEvent>
+    },
+    /// Wraps the [`message_deleted`](https://api.slack.com/events/message/message_deleted) message
+    /// event.
+    MessageDeleted {
+        hidden: bool,
+        channel: String,
+        ts: String,
+        deleted_ts: String
+    },
+    /// Wraps the [`channel_join`](https://api.slack.com/events/message/channel_join) message
+    /// event.
+    ChannelJoin {
+        ts: String,
+        user: String,
+        text: String,
+        inviter: Option<String>
+    },
+    /// Wraps the [`channel_leave`](https://api.slack.com/events/message/channel_leave) message
+    /// event.
+    ChannelLeave {
+        ts: String,
+        user: String,
+        text: String,
+    },
+    /// Wraps the [`channel_topic`](https://api.slack.com/events/message/channel_topic) message
+    /// event.
+    ChannelTopic {
+        ts: String,
+        user: String,
+        topic: String,
+        text: String,
+    },
+    /// Wraps the [`channel_purpose`](https://api.slack.com/events/message/channel_purpose) message
+    /// event.
+    ChannelPurpose {
+        ts: String,
+        user: String,
+        purpose: String,
+        text: String
+    },
+    /// Wraps the [`channel_name`](https://api.slack.com/events/message/channel_name) message
+    /// event.
+    ChannelName {
+        ts: String,
+        user: String,
+        old_name: String,
+        name: String,
+        text: String
+    },
+    /// Wraps the [`channel_archive`](https://api.slack.com/events/message/channel_archive) message
+    /// event.
+    ChannelArchive {
+        ts: String,
+        text: String,
+        user: String,
+        members: Vec<String>
+    },
+    /// Wraps the [`channel_unarchive`](https://api.slack.com/events/message/channel_unarchive)
+    /// message event.
+    ChannelUnarchive {
+        ts: String,
+        text: String,
+        user: String
+    },
+    /// Wraps the [`group_join`](https://api.slack.com/events/message/group_join) message event.
+    GroupJoin {
+        ts: String,
+        user: String,
+        text: String,
+        inviter: Option<String>
+    },
+    /// Wraps the [`group_leave`](https://api.slack.com/events/message/group_leave) message event.
+    GroupLeave {
+        ts: String,
+        user: String,
+        text: String
+    },
+    /// Wraps the [`group_topic`](https://api.slack.com/events/message/group_topic) message event.
+    GroupTopic {
+        ts: String,
+        user: String,
+        topic: String,
+        text: String
+    },
+    /// Wraps the [`group_purpose`](https://api.slack.com/events/message/group_purpose) message
+    /// event.
+    GroupPurpose {
+        ts: String,
+        user: String,
+        purpose: String,
+        text: String
+    },
+    /// Wraps the [`group_name`](https://api.slack.com/events/message/group_name) message event.
+    GroupName {
+        ts: String,
+        user: String,
+        old_name: String,
+        name: String,
+        text: String
+    },
+    /// Wraps the [`group_archive`](https://api.slack.com/events/message/group_archive) message
+    /// event.
+    GroupArchive {
+        ts: String,
+        text: String,
+        user: String,
+        members: Vec<String>
+    },
+    /// Wraps the [`group_unarchive`](https://api.slack.com/events/message/group_unarchive)
+    /// message event.
+    GroupUnarchive {
+        ts: String,
+        text: String,
+        user: String
+    },
+    /// Wraps the [`file_share`](https://api.slack.com/events/message/file_share) message event.
+    FileShare {
+        ts: String,
+        text: String,
+        file: super::File,
+        user: String,
+        upload: bool
+    },
+    /// Wraps the [`file_comment`](https://api.slack.com/events/message/file_comment) message
+    /// event.
+    FileComment {
+        ts: String,
+        text: String,
+        file: super::File,
+        comment: super::Comment
+    },
+    /// Wraps the [`file_mention`](https://api.slack.com/events/message/file_mention) message
+    /// event.
+    FileMention {
+        ts: String,
+        text: String,
+        file: super::File,
+        user: String
+    },
+    /// Wraps the [`pinned_item`](https://api.slack.com/events/message/pinned_item) message event.
+    PinnedItem {
+        user: String,
+        item_type: String,
+        text: String,
+        item: Option<super::Item>,
+        channel: String,
+        ts: String,
+        attachments: Option<Vec<super::Attachment>>
+    },
+    /// Wraps the [`unpinned_item`](https://api.slack.com/events/message/unpinned_item) message
+    /// event.
+    UnpinnedItem {
+        user: String,
+        item_type: String,
+        text: String,
+        item: Option<super::Item>,
+        channel: String,
+        ts: String,
+        attachments: Option<Vec<super::Attachment>>
+    }
+}
+
+impl Decodable for MessageEvent {
+    fn decode<D: Decoder>(d: &mut D) -> Result<MessageEvent, D::Error> {
+        d.read_struct("message", 0, |d| {
+            let ty: Option<String> = try!(d.read_struct_field("subtype", 0, |d| Decodable::decode(d)));
+            if ty.is_none() {
+                return Ok(MessageEvent::Standard {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    is_starred: try!(d.read_struct_field("is_starred", 0, |d| Decodable::decode(d))),
+                    pinned_to: try!(d.read_struct_field("pinned_to", 0, |d| Decodable::decode(d))),
+                    reactions: try!(d.read_struct_field("reactions", 0, |d| Decodable::decode(d))),
+                    edited: try!(d.read_struct_field("edited", 0, |d| Decodable::decode(d))),
+                    attachments: try!(d.read_struct_field("attachments", 0, |d| Decodable::decode(d)))
+                });
+            }
+            let ty = ty.unwrap();
+            if ty == "bot_message" {
+                Ok(MessageEvent::BotMessage {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    bot_id: try!(d.read_struct_field("bot_id", 0, |d| Decodable::decode(d))),
+                    username: try!(d.read_struct_field("username", 0, |d| Decodable::decode(d))),
+                    icons: try!(d.read_struct_field("icons", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "me_message" {
+                Ok(MessageEvent::MeMessage {
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "message_changed" {
+                Ok(MessageEvent::MessageChanged {
+                    hidden: try!(d.read_struct_field("hidden", 0, |d| Decodable::decode(d))),
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "message_deleted" {
+                Ok(MessageEvent::MessageDeleted {
+                    hidden: try!(d.read_struct_field("hidden", 0, |d| Decodable::decode(d))),
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    deleted_ts: try!(d.read_struct_field("deleted_ts", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel_join" {
+                Ok(MessageEvent::ChannelJoin {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    inviter: try!(d.read_struct_field("inviter", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel_leave" {
+                Ok(MessageEvent::ChannelLeave {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel_topic" {
+                Ok(MessageEvent::ChannelTopic {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    topic: try!(d.read_struct_field("topic", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel_purpose" {
+                Ok(MessageEvent::ChannelPurpose {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    purpose: try!(d.read_struct_field("purpose", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel_name" {
+                Ok(MessageEvent::ChannelName {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    old_name: try!(d.read_struct_field("old_name", 0, |d| Decodable::decode(d))),
+                    name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel_archive" {
+                Ok(MessageEvent::ChannelArchive {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    members: try!(d.read_struct_field("members", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel_unarchive" {
+                Ok(MessageEvent::ChannelUnarchive {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "group_join" {
+                Ok(MessageEvent::GroupJoin {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    inviter: try!(d.read_struct_field("inviter", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "group_leave" {
+                Ok(MessageEvent::GroupLeave {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "group_topic" {
+                Ok(MessageEvent::GroupTopic {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    topic: try!(d.read_struct_field("topic", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "group_purpose" {
+                Ok(MessageEvent::GroupPurpose {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    purpose: try!(d.read_struct_field("purpose", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "group_name" {
+                Ok(MessageEvent::GroupName {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    old_name: try!(d.read_struct_field("old_name", 0, |d| Decodable::decode(d))),
+                    name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "group_archive" {
+                Ok(MessageEvent::GroupArchive {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    members: try!(d.read_struct_field("members", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "group_unarchive" {
+                Ok(MessageEvent::GroupUnarchive {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "file_share" {
+                Ok(MessageEvent::FileShare {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    upload: try!(d.read_struct_field("upload", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "file_comment" {
+                Ok(MessageEvent::FileComment {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                    comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "file_mention" {
+                Ok(MessageEvent::FileMention {
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "pinned_item" {
+                Ok(MessageEvent::PinnedItem {
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    item_type: try!(d.read_struct_field("item_type", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    attachments: try!(d.read_struct_field("attachments", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "unpinned_item" {
+                Ok(MessageEvent::UnpinnedItem {
+                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    item_type: try!(d.read_struct_field("item_type", 0, |d| Decodable::decode(d))),
+                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    attachments: try!(d.read_struct_field("attachments", 0, |d| Decodable::decode(d)))
+                })
+            } else {
+                Err(d.error(&format!("Unknown MessageEvent type: {}", ty)))
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::Item;
+    use rustc_serialize::json;
+
+    #[test]
+    fn decode_short_standard_message() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "ts": "1234567890.218332",
+            "user": "U12345678",
+            "text": "Hello world",
+            "channel": "C12345678"
+        }"#).unwrap();
+        match message {
+            MessageEvent::Standard { ts, channel: _, user, text, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                assert_eq!(ts, "1234567890.218332");
+                assert_eq!(text.unwrap(), "Hello world");
+                assert_eq!(user.unwrap(), "U12345678");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_extended_standard_message() {
+        let message: MessageEvent = json::decode(r##"{
+            "type": "message",
+            "ts": "1234567890.218332",
+            "user": "U12345678",
+            "text": "Hello world",
+            "channel": "C12345678",
+            "is_starred": false,
+            "pinned_to": [ "C12345678" ],
+            "reactions": [
+                {
+                    "name": "astonished",
+                    "count": 5,
+                    "users": [ "U12345678", "U87654321" ]
+                }
+            ],
+            "edited": {
+                "user": "U12345678",
+                "ts": "1234567890.218332"
+            },
+            "attachments": [
+                {
+                    "fallback": "Required plain-text summary of the attachment.",
+                    "color": "#36a64f",
+                    "pretext": "Optional text that appears above the attachment block",
+                    "author_name": "Bobby Tables",
+                    "author_link": "http://flickr.com/bobby/",
+                    "author_icon": "http://flickr.com/icons/bobby.jpg",
+                    "title": "Slack API Documentation",
+                    "title_link": "https://api.slack.com/",
+                    "text": "Optional text that appears within the attachment",
+                    "fields": [
+                        {
+                            "title": "Priority",
+                            "value": "High",
+                            "short": false
+                        }
+                    ],
+                    "image_url": "http://my-website.com/path/to/image.jpg",
+                    "thumb_url": "http://example.com/path/to/thumb.png"
+                }
+            ]
+        }"##).unwrap();
+        match message {
+            MessageEvent::Standard { ts: _, channel: _, user: _, text: _, is_starred, pinned_to: _, reactions: _, edited: _, attachments } => {
+                assert_eq!(is_starred, Some(false));
+                assert_eq!(attachments.unwrap()[0].color.as_ref().unwrap(), "#36a64f");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_bot_message() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "bot_message",
+            "ts": "1358877455.000010",
+            "text": "Pushing is the answer",
+            "bot_id": "BB12033",
+            "username": "github",
+            "icons": {
+                "image_24": "http://some.url.com/test.png"
+            }
+        }"#).unwrap();
+        match message {
+            MessageEvent::BotMessage { ts, text, bot_id, username, icons: _ } => {
+                assert_eq!(ts, "1358877455.000010");
+                assert_eq!(text, "Pushing is the answer");
+                assert_eq!(bot_id, "BB12033");
+                assert_eq!(username.unwrap(), "github");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_me_message() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "me_message",
+            "channel": "C2147483705",
+            "user": "U2147483697",
+            "text": "is doing that thing",
+            "ts": "1355517523.000005"
+        }"#).unwrap();
+        match message {
+            MessageEvent::MeMessage { ts, text, user, channel } => {
+                assert_eq!(ts, "1355517523.000005");
+                assert_eq!(text, "is doing that thing");
+                assert_eq!(channel, "C2147483705");
+                assert_eq!(user, "U2147483697");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_message_changed() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "message_changed",
+            "hidden": true,
+            "channel": "C2147483705",
+            "ts": "1358878755.000001",
+            "message": {
+                "type": "message",
+                "user": "U2147483697",
+                "text": "Hello, world!",
+                "ts": "1355517523.000005",
+                "edited": {
+                    "user": "U2147483697",
+                    "ts": "1358878755.000001"
+                }
+            }
+        }"#).unwrap();
+        match message {
+            MessageEvent::MessageChanged { hidden: _, channel, ts, message } => {
+                assert_eq!(ts, "1358878755.000001");
+                assert_eq!(channel, "C2147483705");
+                match *message.clone() {
+                    MessageEvent::Standard { ts: _, channel: _, user, text: _, is_starred: _, pinned_to: _, reactions: _, edited, attachments: _ } => {
+                        assert_eq!(user.unwrap(), "U2147483697");
+                        assert_eq!(edited.unwrap().user, "U2147483697")
+                    },
+                    _ => panic!("Message decoded into incorrect variant.")
+                }
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_message_deleted() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "message_deleted",
+            "hidden": true,
+            "channel": "C2147483705",
+            "ts": "1358878755.000001",
+            "deleted_ts": "1358878749.000002"
+        }"#).unwrap();
+        match message {
+            MessageEvent::MessageDeleted { hidden: _, channel: _, ts, deleted_ts } => {
+                assert_eq!(ts, "1358878755.000001");
+                assert_eq!(deleted_ts, "1358878749.000002");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_channel_join() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "channel_join",
+            "ts": "1358877458.000011",
+            "user": "U2147483828",
+            "text": "<@U2147483828|cal> has joined the channel"
+        }"#).unwrap();
+        match message {
+            MessageEvent::ChannelJoin { user: _, text, ts: _, inviter } => {
+                assert_eq!(text, "<@U2147483828|cal> has joined the channel");
+                assert_eq!(inviter, None);
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_channel_leave() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "channel_leave",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "text": "<@U2147483828|cal> has left the channel"
+        }"#).unwrap();
+        match message {
+            MessageEvent::ChannelLeave { user: _, text, ts: _ } => {
+                assert_eq!(text, "<@U2147483828|cal> has left the channel");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_channel_topic() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "channel_topic",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "topic": "hello world",
+            "text": "<@U2147483828|cal> set the channel topic: hello world"
+        }"#).unwrap();
+        match message {
+            MessageEvent::ChannelTopic { user: _, text, ts: _, topic } => {
+                assert_eq!(topic, "hello world");
+                assert_eq!(text, "<@U2147483828|cal> set the channel topic: hello world");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_channel_purpose() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "channel_purpose",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "purpose": "whatever",
+            "text": "<@U2147483828|cal> set the channel purpose: whatever"
+        }"#).unwrap();
+        match message {
+            MessageEvent::ChannelPurpose { user: _, text, ts: _, purpose } => {
+                assert_eq!(purpose, "whatever");
+                assert_eq!(text, "<@U2147483828|cal> set the channel purpose: whatever");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_channel_name() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "channel_name",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "old_name": "random",
+            "name": "watercooler",
+            "text": "<@U2147483828|cal> has renamed the channek from \"random\" to \"watercooler\""
+        }"#).unwrap();
+        match message {
+            MessageEvent::ChannelName { ts: _, user: _, old_name, name, text: _ } => {
+                assert_eq!(old_name, "random");
+                assert_eq!(name, "watercooler");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_channel_archive() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "channel_archive",
+            "ts": "1361482916.000003",
+            "text": "<U1234|@cal> archived the channel",
+            "user": "U1234",
+            "members": ["U1234", "U5678"]
+        }"#).unwrap();
+        match message {
+            MessageEvent::ChannelArchive { ts: _, text: _, user, members } => {
+                assert_eq!(user, "U1234");
+                assert_eq!(members[1], "U5678");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_channel_unarchive() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "channel_unarchive",
+            "ts": "1361482916.000003",
+            "text": "<U1234|@cal> un-archived the channel",
+            "user": "U1234"
+        }"#).unwrap();
+        match message {
+            MessageEvent::ChannelUnarchive { ts: _, text: _, user } => {
+                assert_eq!(user, "U1234");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_group_join() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "group_join",
+            "ts": "1358877458.000011",
+            "user": "U2147483828",
+            "text": "<@U2147483828|cal> has joined the group"
+        }"#).unwrap();
+        match message {
+            MessageEvent::GroupJoin { user: _, text, ts: _, inviter } => {
+                assert_eq!(text, "<@U2147483828|cal> has joined the group");
+                assert_eq!(inviter, None);
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_group_leave() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "group_leave",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "text": "<@U2147483828|cal> has left the group"
+        }"#).unwrap();
+        match message {
+            MessageEvent::GroupLeave { user: _, text, ts: _ } => {
+                assert_eq!(text, "<@U2147483828|cal> has left the group");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_group_topic() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "group_topic",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "topic": "hello world",
+            "text": "<@U2147483828|cal> set the group topic: hello world"
+        }"#).unwrap();
+        match message {
+            MessageEvent::GroupTopic { user: _, text, ts: _, topic } => {
+                assert_eq!(topic, "hello world");
+                assert_eq!(text, "<@U2147483828|cal> set the group topic: hello world");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_group_purpose() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "group_purpose",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "purpose": "whatever",
+            "text": "<@U2147483828|cal> set the group purpose: whatever"
+        }"#).unwrap();
+        match message {
+            MessageEvent::GroupPurpose { user: _, text, ts: _, purpose } => {
+                assert_eq!(purpose, "whatever");
+                assert_eq!(text, "<@U2147483828|cal> set the group purpose: whatever");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_group_name() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "group_name",
+            "ts": "1358877455.000010",
+            "user": "U2147483828",
+            "old_name": "random",
+            "name": "watercooler",
+            "text": "<@U2147483828|cal> has renamed the group from \"random\" to \"watercooler\""
+        }"#).unwrap();
+        match message {
+            MessageEvent::GroupName { ts: _, user: _, old_name, name, text: _ } => {
+                assert_eq!(old_name, "random");
+                assert_eq!(name, "watercooler");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_group_archive() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "group_archive",
+            "ts": "1361482916.000003",
+            "text": "<U1234|@cal> archived the group",
+            "user": "U1234",
+            "members": ["U1234", "U5678"]
+        }"#).unwrap();
+        match message {
+            MessageEvent::GroupArchive { ts: _, text: _, user, members } => {
+                assert_eq!(user, "U1234");
+                assert_eq!(members[1], "U5678");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_group_unarchive() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "group_unarchive",
+            "ts": "1361482916.000003",
+            "text": "<U1234|@cal> un-archived the group",
+            "user": "U1234"
+        }"#).unwrap();
+        match message {
+            MessageEvent::GroupUnarchive { ts: _, text: _, user } => {
+                assert_eq!(user, "U1234");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_file_share() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "file_share",
+            "ts": "1358877455.000010",
+            "text": "<@cal> uploaded a file: <https:...7.png|7.png>",
+            "file": {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            },
+            "user": "U2147483697",
+            "upload": true
+        }"#).unwrap();
+        match message {
+            MessageEvent::FileShare { ts: _, file, text, user: _, upload: _ } => {
+                assert_eq!(text, "<@cal> uploaded a file: <https:...7.png|7.png>");
+                assert_eq!(file.id, "F12345678");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_file_comment() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "file_comment",
+            "ts": "1358877455.000010",
+            "text": "<@cal> commented on a file: ...",
+            "file": {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            },
+            "comment": {
+                "id": "Fc12345678",
+                "timestamp": 1356032811,
+                "user": "U12345678",
+                "comment": "This is a comment"
+            }
+        }"#).unwrap();
+        match message {
+            MessageEvent::FileComment { ts: _, file, text, comment } => {
+                assert_eq!(text, "<@cal> commented on a file: ...");
+                assert_eq!(file.id, "F12345678");
+                assert_eq!(comment.id, "Fc12345678");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_file_mention() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "file_mention",
+            "ts": "1358877455.000010",
+            "text": "<@cal> mentioned a file: <https:...7.png|7.png>",
+            "file": {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            },
+            "user": "U2147483697"
+        }"#).unwrap();
+        match message {
+            MessageEvent::FileMention { ts: _, file, text, user: _ } => {
+                assert_eq!(text, "<@cal> mentioned a file: <https:...7.png|7.png>");
+                assert_eq!(file.id, "F12345678");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_pinned_item() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "pinned_item",
+            "user": "U024BE7LH",
+            "item_type": "F",
+            "text": "<@U024BE7LH|cal> pinned their Image <https:...7.png|7.png> to this channel.",
+            "item": {
+                "type": "file",
+                "file": {
+                    "id": "F12345678",
+                    "created": 1444929467,
+                    "timestamp": 1444929467,
+                    "name": "test_img.png",
+                    "title": "test_img",
+                    "mimetype": "image\/png",
+                    "filetype": "png",
+                    "pretty_type": "PNG",
+                    "user": "U12345678",
+                    "editable": false,
+                    "size": 16153,
+                    "mode": "hosted",
+                    "is_external": false,
+                    "external_type": "",
+                    "is_public": true,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "username": "",
+                    "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                    "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                    "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                    "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                    "thumb_360_w": 360,
+                    "thumb_360_h": 28,
+                    "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                    "thumb_480_w": 480,
+                    "thumb_480_h": 37,
+                    "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                    "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                    "thumb_720_w": 720,
+                    "thumb_720_h": 56,
+                    "image_exif_rotation": 1,
+                    "original_w": 895,
+                    "original_h": 69,
+                    "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                    "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                    "channels": [
+                        "C12345678"
+                    ],
+                    "groups": [
+
+                    ],
+                    "ims": [
+
+                    ],
+                    "comments_count": 0
+                }
+            },
+            "channel": "C02ELGNBH",
+            "ts": "1360782804.083113"
+        }"#).unwrap();
+        match message {
+            MessageEvent::PinnedItem { ts: _, user: _, item_type, text: _, item, channel: _, attachments: _ } => {
+                assert_eq!(item_type, "F");
+                match item.unwrap() {
+                    Item::File { file } => {
+                        assert_eq!(file.id, "F12345678");
+                    },
+                    _ => panic!("Item decoded into incorrect variant.")
+                }
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_pinned_item_no_item() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "pinned_item",
+            "user": "U12345678",
+            "item_type": "C",
+            "attachments": [
+                {
+                    "color": "D0D0D0",
+                    "fallback": "Test fallback message",
+                    "ts": "1445226476.000002",
+                    "text": "test message",
+                    "author_link": "test-team.slack.com/team/user123",
+                    "author_icon": "https://secure.gravatar.com/avatar/PRIVATE_GUID.jpg",
+                    "mrkdwn_in": ["text"]
+                }
+            ],
+            "text": "<@U12345678|user123> pinned a message to this channel.",
+            "channel": "C12345678",
+            "ts": "1445226479.000003"
+        }"#).unwrap();
+        match message {
+            MessageEvent::PinnedItem { ts: _, user: _, item_type: _, text: _, item, channel: _, attachments } => {
+                assert!(item.is_none());
+                assert_eq!(attachments.unwrap()[0].color.as_ref().unwrap(), "D0D0D0");
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn decode_unpinned_item() {
+        let message: MessageEvent = json::decode(r#"{
+            "type": "message",
+            "subtype": "unpinned_item",
+            "user": "USLACKBOT",
+            "item_type": "G",
+            "text": "<@U024BE7LH|cal> unpinned the message you pinned to the secretplans group.",
+            "item": {
+                "type": "file",
+                "file": {
+                    "id": "F12345678",
+                    "created": 1444929467,
+                    "timestamp": 1444929467,
+                    "name": "test_img.png",
+                    "title": "test_img",
+                    "mimetype": "image\/png",
+                    "filetype": "png",
+                    "pretty_type": "PNG",
+                    "user": "U12345678",
+                    "editable": false,
+                    "size": 16153,
+                    "mode": "hosted",
+                    "is_external": false,
+                    "external_type": "",
+                    "is_public": true,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "username": "",
+                    "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                    "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                    "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                    "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                    "thumb_360_w": 360,
+                    "thumb_360_h": 28,
+                    "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                    "thumb_480_w": 480,
+                    "thumb_480_h": 37,
+                    "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                    "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                    "thumb_720_w": 720,
+                    "thumb_720_h": 56,
+                    "image_exif_rotation": 1,
+                    "original_w": 895,
+                    "original_h": 69,
+                    "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                    "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                    "channels": [
+                        "C12345678"
+                    ],
+                    "groups": [
+
+                    ],
+                    "ims": [
+
+                    ],
+                    "comments_count": 0
+                }
+            },
+            "channel": "G024BE91L",
+            "ts": "1360782804.083113"
+        }"#).unwrap();
+        match message {
+            MessageEvent::UnpinnedItem { ts: _, user: _, item_type, text: _, item, channel: _, attachments: _ } => {
+                assert_eq!(item_type, "G");
+                match item.unwrap() {
+                    Item::File { file } => {
+                        assert_eq!(file.id, "F12345678");
+                    },
+                    _ => panic!("Item decoded into incorrect variant.")
+                }
+            },
+            _ => panic!("Message decoded into incorrect variant.")
+        };
+    }
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,0 +1,81 @@
+//! Low-level, direct interface for the [Slack Web API](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use std::io::Read;
+
+use hyper;
+use rustc_serialize::{json,Decodable};
+
+use ::error::Error;
+
+#[cfg(test)]
+#[macro_use]
+pub mod test_helpers {
+    macro_rules! mock_slack_responder {
+        ($name:ident, $json:expr) => {
+            mock_connector!($name {
+                "https://slack.com" => "HTTP/1.1 200 OK\r\n\r\n".to_owned() + $json
+            });
+        }
+    }
+}
+
+mod types;
+pub use self::types::*;
+
+mod message_events;
+pub use self::message_events::MessageEvent;
+
+pub mod api;
+pub mod auth;
+pub mod channels;
+pub mod chat;
+pub mod emoji;
+pub mod files;
+pub mod groups;
+pub mod im;
+pub mod oauth;
+pub mod pins;
+pub mod reactions;
+pub mod rtm;
+pub mod search;
+pub mod stars;
+pub mod team;
+pub mod users;
+
+pub type ApiResult<T> = Result<T, Error>;
+
+/// Make an API call to Slack. Takes a map of parameters that get appended to the request as query
+/// params. Returns the response body string after checking it has "ok": true, or an Error
+fn make_api_call<'a, T: Decodable>(client: &hyper::Client, method: &str, custom_params: HashMap<&str, &'a str>) -> ApiResult<T> {
+    let url_string = format!("https://slack.com/api/{}", method);
+    let mut url = try!(hyper::Url::parse(&url_string));
+
+    url.set_query_from_pairs(custom_params.into_iter());
+
+    let response = try!(client.get(url).send());
+    transform_api_result(response)
+}
+
+/// Make an API call to Slack that includes the configured token. Takes a map of parameters that
+/// get appended to the request as query params. Returns the response body string after checking it
+/// has `"ok": true`, or an Error
+fn make_authed_api_call<'a, T: Decodable>(client: &hyper::Client, method: &str, token: &'a str, mut custom_params: HashMap<&str, &'a str>) -> ApiResult<T> {
+    custom_params.insert("token", token);
+    make_api_call(client, method, custom_params)
+}
+
+fn transform_api_result<T: Decodable>(mut res: hyper::client::response::Response) -> ApiResult<T> {
+    let mut res_str = String::new();
+    try!(res.read_to_string(&mut res_str));
+
+    let raw_json = try!(json::Json::from_str(&res_str));
+    let jobj = try!(raw_json.as_object().ok_or(Error::Api(format!("bad slack json response (not an object) {:?}", raw_json))));
+    let ok = try!(jobj.get("ok").ok_or(Error::Api(format!("slack json reponse does not contain \"ok\" field {:?}", raw_json))));
+    let is_ok = try!(ok.as_boolean().ok_or(Error::Api(format!("slack json reponse \"ok\" is not a boolean: {:?}", raw_json))));
+    if !is_ok {
+        return Err(Error::Api(format!("slack json reponse \"ok\" is not true: {:?}", raw_json)));
+    }
+
+    Ok(try!(json::decode(&res_str)))
+}

--- a/src/api/oauth.rs
+++ b/src/api/oauth.rs
@@ -1,0 +1,82 @@
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use std::io::Read;
+use hyper;
+use rustc_serialize::json;
+
+use super::ApiResult;
+use ::error::Error;
+
+/// Exchanges a temporary OAuth code for an API token.
+///
+/// Wraps https://api.slack.com/methods/oauth.access
+pub fn access(client: &hyper::Client, client_id: &str, client_secret: &str, code: &str, redirect_uri: Option<&str>) -> ApiResult<AccessResponse> {
+    let mut params = HashMap::new();
+    params.insert("client_id", client_id);
+    params.insert("client_secret", client_secret);
+    params.insert("code", code);
+    if let Some(redirect_uri) = redirect_uri {
+        params.insert("redirect_uri", redirect_uri);
+    }
+
+    let mut url = try!(hyper::Url::parse("https://slack.com/api/oauth.access"));
+    url.set_query_from_pairs(params.into_iter());
+
+    let response = try!(client.get(url).send());
+    transform_oauth_response(response)
+}
+
+fn transform_oauth_response(mut res: hyper::client::response::Response) -> ApiResult<AccessResponse> {
+    let mut res_str = String::new();
+    try!(res.read_to_string(&mut res_str));
+
+    let raw_json = try!(json::Json::from_str(&res_str));
+    let jobj = try!(raw_json.as_object().ok_or(Error::Api(format!("bad slack json response (not an object) {:?}", raw_json))));
+    if let Some(ok) = jobj.get("ok") {
+        let is_ok = try!(ok.as_boolean().ok_or(Error::Api(format!("slack json reponse \"ok\" is not a boolean: {:?}", raw_json))));
+        if !is_ok {
+            return Err(Error::Api(format!("slack json reponse \"ok\" is not true: {:?}", raw_json)));
+        }
+    }
+
+    Ok(try!(json::decode(&res_str)))
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AccessResponse {
+    pub access_token: String,
+    pub scope: String
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = access(&client, "TEST_ID", "TEST_TOKEN", "TEST_CODE", None);
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockListOkResponder,
+        r#"{
+            "access_token": "xoxt-23984754863-2348975623103",
+            "scope": "read"
+        }"#
+    );
+
+    #[test]
+    fn access_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = access(&client, "TEST_ID", "TEST_TOKEN", "TEST_CODE", None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().access_token, "xoxt-23984754863-2348975623103");
+    }
+}

--- a/src/api/pins.rs
+++ b/src/api/pins.rs
@@ -1,0 +1,244 @@
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Pins an item to a channel.
+///
+/// Wraps https://api.slack.com/methods/pins.add
+pub fn add(client: &hyper::Client, token: &str, channel: &str, file: Option<&str>, file_comment: Option<&str>, timestamp: Option<&str>) -> ApiResult<AddResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    if let Some(file) = file {
+        params.insert("file", file);
+    }
+    if let Some(file_comment) = file_comment {
+        params.insert("file_comment", file_comment);
+    }
+    if let Some(timestamp) = timestamp {
+        params.insert("timestamp", timestamp);
+    }
+    make_authed_api_call(client, "pins.add", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AddResponse;
+
+/// Lists items pinned to a channel.
+///
+/// Wraps https://api.slack.com/methods/pins.list
+pub fn list(client: &hyper::Client, token: &str, channel: &str) -> ApiResult<ListResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    make_authed_api_call(client, "pins.list", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub items: Vec<super::Item>
+}
+
+/// Un-pins an item from a channel.
+///
+/// Wraps https://api.slack.com/methods/pins.remove
+pub fn remove(client: &hyper::Client, token: &str, channel: &str, file: Option<&str>, file_comment: Option<&str>, timestamp: Option<&str>) -> ApiResult<RemoveResponse> {
+    let mut params = HashMap::new();
+    params.insert("channel", channel);
+    if let Some(file) = file {
+        params.insert("file", file);
+    }
+    if let Some(file_comment) = file_comment {
+        params.insert("file_comment", file_comment);
+    }
+    if let Some(timestamp) = timestamp {
+        params.insert("timestamp", timestamp);
+    }
+    make_authed_api_call(client, "pins.remove", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct RemoveResponse;
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+    use super::super::Item;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = list(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockAddOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn add_ok_response() {
+        let client = hyper::Client::with_connector(MockAddOkResponder::default());
+        let result = add(&client, "TEST_TOKEN", "TEST_CHANNEL", None, None, Some("1234567890.123456"));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockListOkResponder, r#"{
+        "ok": true,
+        "items": [
+            {
+                "type": "message",
+                "channel": "C2147483705",
+                "message": {
+                    "type": "message",
+                    "user": "U024BE7LH",
+                    "text": "lol",
+                    "ts": "1444078138.000084"
+                }
+            },
+            {
+                "type": "file",
+                "file": {
+                    "id": "F12345678",
+                    "created": 1444929467,
+                    "timestamp": 1444929467,
+                    "name": "test_img.png",
+                    "title": "test_img",
+                    "mimetype": "image\/png",
+                    "filetype": "png",
+                    "pretty_type": "PNG",
+                    "user": "U12345678",
+                    "editable": false,
+                    "size": 16153,
+                    "mode": "hosted",
+                    "is_external": false,
+                    "external_type": "",
+                    "is_public": true,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "username": "",
+                    "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                    "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                    "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                    "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                    "thumb_360_w": 360,
+                    "thumb_360_h": 28,
+                    "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                    "thumb_480_w": 480,
+                    "thumb_480_h": 37,
+                    "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                    "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                    "thumb_720_w": 720,
+                    "thumb_720_h": 56,
+                    "image_exif_rotation": 1,
+                    "original_w": 895,
+                    "original_h": 69,
+                    "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                    "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                    "channels": [
+                        "C12345678"
+                    ],
+                    "groups": [
+
+                    ],
+                    "ims": [
+
+                    ],
+                    "comments_count": 0
+                }
+            },
+            {
+                "type": "file_comment",
+                "file": {
+                    "id": "F12345678",
+                    "created": 1444929467,
+                    "timestamp": 1444929467,
+                    "name": "test_img.png",
+                    "title": "test_img",
+                    "mimetype": "image\/png",
+                    "filetype": "png",
+                    "pretty_type": "PNG",
+                    "user": "U12345678",
+                    "editable": false,
+                    "size": 16153,
+                    "mode": "hosted",
+                    "is_external": false,
+                    "external_type": "",
+                    "is_public": true,
+                    "public_url_shared": false,
+                    "display_as_bot": false,
+                    "username": "",
+                    "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                    "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                    "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                    "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                    "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                    "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                    "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                    "thumb_360_w": 360,
+                    "thumb_360_h": 28,
+                    "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                    "thumb_480_w": 480,
+                    "thumb_480_h": 37,
+                    "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                    "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                    "thumb_720_w": 720,
+                    "thumb_720_h": 56,
+                    "image_exif_rotation": 1,
+                    "original_w": 895,
+                    "original_h": 69,
+                    "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                    "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                    "channels": [
+                        "C12345678"
+                    ],
+                    "groups": [
+
+                    ],
+                    "ims": [
+
+                    ],
+                    "comments_count": 0
+                },
+                "comment": {
+                    "id": "Fc12345678",
+                    "timestamp": 1356032811,
+                    "user": "U12345678",
+                    "comment": "This is a comment"
+                }
+            }
+        ]
+    }"#);
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN", "TEST_CHANNEL");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().items[0] {
+            Item::Message { channel: ref c, message: _ } => assert_eq!(c, "C2147483705"),
+            _ => panic!("Incorrect item type. Expected message.")
+        }
+    }
+
+    mock_slack_responder!(MockRemoveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn remove_ok_response() {
+        let client = hyper::Client::with_connector(MockRemoveOkResponder::default());
+        let result = remove(&client, "TEST_TOKEN", "TEST_CHANNEL", None, None, Some("1234567890.123456"));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+}

--- a/src/api/reactions.rs
+++ b/src/api/reactions.rs
@@ -1,0 +1,312 @@
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Adds a reaction to an item.
+///
+/// Wraps https://api.slack.com/methods/reactions.add
+pub fn add(client: &hyper::Client, token: &str, name: &str, file: Option<&str>, file_comment: Option<&str>, channel: Option<&str>, timestamp: Option<&str>) -> ApiResult<AddResponse> {
+    let mut params = HashMap::new();
+    params.insert("name", name);
+    if let Some(file) = file {
+        params.insert("file", file);
+    }
+    if let Some(file_comment) = file_comment {
+        params.insert("file_comment", file_comment);
+    }
+    if let Some(channel) = channel {
+        params.insert("channel", channel);
+    }
+    if let Some(timestamp) = timestamp {
+        params.insert("timestamp", timestamp);
+    }
+    make_authed_api_call(client, "reactions.add", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AddResponse;
+
+/// Gets reactions for an item.
+///
+/// Wraps https://api.slack.com/methods/reactions.get
+pub fn get(client: &hyper::Client, token: &str, file: Option<&str>, file_comment: Option<&str>, channel: Option<&str>, timestamp: Option<&str>, full: Option<&str>) -> ApiResult<GetResponse> {
+    let mut params = HashMap::new();
+    if let Some(file) = file {
+        params.insert("file", file);
+    }
+    if let Some(file_comment) = file_comment {
+        params.insert("file_comment", file_comment);
+    }
+    if let Some(channel) = channel {
+        params.insert("channel", channel);
+    }
+    if let Some(timestamp) = timestamp {
+        params.insert("timestamp", timestamp);
+    }
+    if let Some(full) = full {
+        params.insert("full", full);
+    }
+    make_authed_api_call(client, "reactions.get", token, params)
+}
+
+// This is an Item as returned by `reactions.list`, but instead of being a nested object like all
+// of the other endpoints is instead inlined at the top level.
+pub type GetResponse = super::Item;
+
+/// Lists reactions made by a user.
+///
+/// Wraps https://api.slack.com/methods/reactions.list
+pub fn list(client: &hyper::Client, token: &str, user: Option<&str>, full: Option<&str>, count: Option<u32>, page: Option<u32>) -> ApiResult<ListResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params = HashMap::new();
+    if let Some(user) = user {
+        params.insert("user", user);
+    }
+    if let Some(full) = full {
+        params.insert("full", full);
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "reactions.list", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub items: Vec<super::Item>,
+    pub paging: super::Pagination
+}
+
+/// Removes a reaction from an item.
+///
+/// Wraps https://api.slack.com/methods/reactions.remove
+pub fn remove(client: &hyper::Client, token: &str, name: &str, file: Option<&str>, file_comment: Option<&str>, channel: Option<&str>, timestamp: Option<&str>) -> ApiResult<RemoveResponse> {
+    let mut params = HashMap::new();
+    params.insert("name", name);
+    if let Some(file) = file {
+        params.insert("file", file);
+    }
+    if let Some(file_comment) = file_comment {
+        params.insert("file_comment", file_comment);
+    }
+    if let Some(channel) = channel {
+        params.insert("channel", channel);
+    }
+    if let Some(timestamp) = timestamp {
+        params.insert("timestamp", timestamp);
+    }
+    make_authed_api_call(client, "reactions.remove", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct RemoveResponse;
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+    use super::super::Item;
+    use super::super::MessageEvent;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = add(&client, "TEST_TOKEN", "thumbsup", None, None, Some("C1234567890"), Some("1234567890.123456"));
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockAddOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn add_ok_response() {
+        let client = hyper::Client::with_connector(MockAddOkResponder::default());
+        let result = add(&client, "TEST_TOKEN", "thumbsup", None, None, Some("C1234567890"), Some("1234567890.123456"));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockGetOkResponder,
+        r#"{
+            "ok": true,
+            "type": "message",
+            "channel": "C1234567890",
+            "message": {
+                "type": "message",
+                "channel": "C1234567890",
+                "user": "U2147483697",
+                "text": "Hello world",
+                "ts": "1234567890.123456",
+                "reactions": [
+                    {
+                        "name": "astonished",
+                        "count": 3,
+                        "users": [ "U1", "U2", "U3" ]
+                    },
+                    {
+                        "name": "clock1",
+                        "count": 2,
+                        "users": [ "U1", "U2", "U3" ]
+                    }
+                ]
+            }
+        }"#
+    );
+
+    #[test]
+    fn get_ok_response() {
+        let client = hyper::Client::with_connector(MockGetOkResponder::default());
+        let result = get(&client, "TEST_TOKEN", None, None, Some("C1234567890"), Some("1234567890.123456"), None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().clone() {
+            Item::Message { channel: c, message: m } => {
+                assert_eq!(c, "C1234567890");
+                match *m.clone() {
+                    MessageEvent::Standard { ts: _, channel: _, user: _, text, is_starred: _, pinned_to: _, reactions, edited: _, attachments: _ } => {
+                        assert_eq!(text.unwrap(), "Hello world");
+                        assert_eq!(reactions.unwrap()[0].name, "astonished");
+                    },
+                    _ => panic!("Message decoded into incorrect variant.")
+                }
+            },
+            _ => panic!("Item decoded into incorrect variant.")
+        };
+    }
+
+    mock_slack_responder!(MockListOkResponder,
+        r#"{
+            "ok": true,
+            "items": [
+                {
+                    "type": "message",
+                    "channel": "C1234567890",
+                    "message": {
+                        "type": "message",
+                        "channel": "C1234567890",
+                        "user": "U2147483697",
+                        "text": "Hello world",
+                        "ts": "1234567890.123456",
+                        "reactions": [
+                            {
+                                "name": "astonished",
+                                "count": 3,
+                                "users": [ "U1", "U2", "U3" ]
+                            },
+                            {
+                                "name": "clock1",
+                                "count": 2,
+                                "users": [ "U1", "U2", "U3" ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "type": "file",
+                    "file": {
+                        "id": "F12345678",
+                        "created": 1444929467,
+                        "timestamp": 1444929467,
+                        "name": "test_img.png",
+                        "title": "test_img",
+                        "mimetype": "image\/png",
+                        "filetype": "png",
+                        "pretty_type": "PNG",
+                        "user": "U12345678",
+                        "editable": false,
+                        "size": 16153,
+                        "mode": "hosted",
+                        "is_external": false,
+                        "external_type": "",
+                        "is_public": true,
+                        "public_url_shared": false,
+                        "display_as_bot": false,
+                        "username": "",
+                        "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                        "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                        "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                        "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                        "thumb_360_w": 360,
+                        "thumb_360_h": 28,
+                        "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                        "thumb_480_w": 480,
+                        "thumb_480_h": 37,
+                        "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                        "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                        "thumb_720_w": 720,
+                        "thumb_720_h": 56,
+                        "image_exif_rotation": 1,
+                        "original_w": 895,
+                        "original_h": 69,
+                        "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                        "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                        "channels": [
+                            "C12345678"
+                        ],
+                        "groups": [
+
+                        ],
+                        "ims": [
+
+                        ],
+                        "comments_count": 0,
+                        "reactions": [
+                            {
+                                "name": "thumbsup",
+                                "count": 1,
+                                "users": [ "U1" ]
+                            }
+                        ]
+                    }
+                }
+            ],
+            "paging": {
+                "count": 100,
+                "total": 5,
+                "page": 1,
+                "pages": 1
+            }
+        }"#
+    );
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN", None, None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().items[1] {
+            Item::File { file: ref f } => {
+                assert_eq!(f.id, "F12345678");
+                assert_eq!(f.reactions.as_ref().unwrap()[0].name, "thumbsup");
+            },
+            _ => panic!("Item decoded into incorrect variant.")
+        };
+    }
+
+    mock_slack_responder!(MockRemoveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn remove_ok_response() {
+        let client = hyper::Client::with_connector(MockRemoveOkResponder::default());
+        let result = remove(&client, "TEST_TOKEN", "thumbsup", None, None, Some("C1234567890"), Some("1234567890.123456"));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+}

--- a/src/api/rtm.rs
+++ b/src/api/rtm.rs
@@ -1,0 +1,321 @@
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Starts a Real Time Messaging session.
+///
+/// Wraps https://api.slack.com/methods/rtm.start
+pub fn start(client: &hyper::Client, token: &str, simple_latest: Option<bool>, no_unreads: Option<bool>) -> ApiResult<StartResponse> {
+    let mut params = HashMap::new();
+    if let Some(simple_latest) = simple_latest {
+        params.insert("simple_latest", if simple_latest { "1" } else { "0" });
+    }
+    if let Some(no_unreads) = no_unreads {
+        params.insert("no_unreads", if no_unreads { "1" } else { "0" });
+    }
+    make_authed_api_call(client, "rtm.start", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Bot {
+    pub id: String,
+    pub deleted: bool,
+    pub name: String,
+    pub icons: Option<HashMap<String,String>>
+}
+
+// We've left out the prefs field for now
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SelfData {
+    pub id: String,
+    pub name: String,
+    pub created: i64,
+    pub manual_presence: String,
+}
+
+#[derive(Clone,Debug)]
+pub struct StartResponse {
+    pub url: String,
+    pub self_data: SelfData,
+    pub team: super::Team,
+    pub users: Vec<super::User>,
+    pub channels: Vec<super::Channel>,
+    pub groups: Vec<super::Group>,
+    pub ims: Vec<super::Im>,
+    pub bots: Vec<Bot>
+}
+
+// This is an ugly hack, we have to compile with --pretty expanded and fix up self to map to self_data.
+// An alternative would be using serde, but it won't do what we need on stable.
+impl ::rustc_serialize::Decodable for StartResponse {
+    fn decode<__D: ::rustc_serialize::Decoder>(__arg_0: &mut __D)
+     -> ::std::result::Result<StartResponse, __D::Error> {
+        __arg_0.read_struct("StartResponse", 8usize, |_d| -> _ {
+                            ::std::result::Result::Ok(StartResponse{url:
+                                                                   match _d.read_struct_field("url",
+                                                                                              0usize,
+                                                                                              ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },
+                                                               self_data:
+                                                                   match _d.read_struct_field("self",
+                                                                                              1usize,
+                                                                                              ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },
+                                                               team:
+                                                                   match _d.read_struct_field("team",
+                                                                                              2usize,
+                                                                                              ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },
+                                                               users:
+                                                                   match _d.read_struct_field("users",
+                                                                                              3usize,
+                                                                                              ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },
+                                                               channels:
+                                                                   match _d.read_struct_field("channels",
+                                                                                              4usize,
+                                                                                              ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },
+                                                               groups:
+                                                                   match _d.read_struct_field("groups",
+                                                                                              5usize,
+                                                                                              ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },
+                                                               ims:
+                                                                   match _d.read_struct_field("ims",
+                                                                                              6usize,
+                                                                                              ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },
+                                                               bots:
+                                                                   match _d.read_struct_field("bots",
+                                                                                          7usize,
+                                                                                          ::rustc_serialize::Decodable::decode)
+                                                                       {
+                                                                       ::std::result::Result::Ok(__try_var)
+                                                                       =>
+                                                                       __try_var,
+                                                                       ::std::result::Result::Err(__try_var)
+                                                                       =>
+                                                                       return ::std::result::Result::Err(__try_var),
+                                                                   },}) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = start(&client, "TEST_TOKEN", None, None);
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockStartOkResponder, r#"
+        {
+            "ok": true,
+            "url": "wss:\/\/ms9.slack-msgs.com\/websocket\/7I5yBpcvk",
+            "self": {
+                "id": "U023BECGF",
+                "name": "bobby",
+                "prefs": {},
+                "created": 1402463766,
+                "manual_presence": "active"
+            },
+            "team": {
+                "id": "T024BE7LD",
+                "name": "Example Team",
+                "email_domain": "",
+                "domain": "example",
+                "msg_edit_window_mins": -1,
+                "over_storage_limit": false,
+                "prefs": {},
+                "plan": "std"
+            },
+            "users": [
+                {
+                    "id": "U023BECGF",
+                    "name": "bobby",
+                    "deleted": false,
+                    "color": "9f69e7",
+                    "profile": {
+                        "first_name": "Bobby",
+                        "last_name": "Tables",
+                        "real_name": "Bobby Tables",
+                        "email": "bobby@slack.com",
+                        "skype": "my-skype-name",
+                        "phone": "+1 (123) 456 7890",
+                        "image_24": "https:\/\/...",
+                        "image_32": "https:\/\/...",
+                        "image_48": "https:\/\/...",
+                        "image_72": "https:\/\/...",
+                        "image_192": "https:\/\/..."
+                    },
+                    "is_admin": true,
+                    "is_owner": true,
+                    "is_primary_owner": true,
+                    "is_restricted": false,
+                    "is_ultra_restricted": false,
+                    "has_2fa": false,
+                    "two_factor_type": "sms",
+                    "has_files": true
+                }
+            ],
+            "channels": [
+                {
+                    "id": "C024BE91L",
+                    "name": "fun",
+                    "is_channel": true,
+                    "created": 1360782804,
+                    "creator": "U024BE7LH",
+                    "is_archived": false,
+                    "is_general": false,
+                    "members": [
+                        "U024BE7LH"
+                    ],
+                    "topic": {
+                        "value": "Fun times",
+                        "creator": "U024BE7LV",
+                        "last_set": 1369677212
+                    },
+                    "purpose": {
+                        "value": "This channel is for fun",
+                        "creator": "U024BE7LH",
+                        "last_set": 1360782804
+                    },
+                    "is_member": true,
+                    "last_read": "1401383885.000061",
+                    "latest": "1401383885.000061",
+                    "unread_count": 0,
+                    "unread_count_display": 0
+                }
+            ],
+            "groups": [
+                {
+                    "id": "G024BE91L",
+                    "name": "secretplans",
+                    "is_group": true,
+                    "created": 1360782804,
+                    "creator": "U024BE7LH",
+                    "is_archived": false,
+                    "members": [
+                        "U024BE7LH"
+                    ],
+                    "topic": {
+                        "value": "Secret plans on hold",
+                        "creator": "U024BE7LV",
+                        "last_set": 1369677212
+                    },
+                    "purpose": {
+                        "value": "Discuss secret plans that no-one else should know",
+                        "creator": "U024BE7LH",
+                        "last_set": 1360782804
+                    },
+                    "last_read": "1401383885.000061",
+                    "latest": "1401383885.000061",
+                    "unread_count": 0,
+                    "unread_count_display": 0
+                }
+            ],
+            "ims": [
+                {
+                    "id": "D024BFF1M",
+                    "is_im": true,
+                    "user": "U024BE7LH",
+                    "created": 1360782804,
+                    "is_user_deleted": false
+                }
+            ],
+            "bots": [
+                {
+                    "id": "B87654321",
+                    "deleted": false,
+                    "name": "gdrive"
+                },
+                {
+                    "id": "B12345678",
+                    "deleted": false,
+                    "name": "bot",
+                    "icons": {
+                        "image_48": "https:\/\/slack.global.ssl.fastly.net\/BOT_ID\/img\/services\/bots_48.png"
+                    }
+                }
+            ]
+        }
+    "#);
+
+    #[test]
+    fn start_ok_response() {
+        let client = hyper::Client::with_connector(MockStartOkResponder::default());
+        let result = start(&client, "TEST_TOKEN", Some(true), None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.url, "wss://ms9.slack-msgs.com/websocket/7I5yBpcvk");
+        assert_eq!(result.self_data.id, "U023BECGF");
+        assert_eq!(result.team.id, "T024BE7LD");
+        assert_eq!(result.users[0].id, "U023BECGF");
+        assert_eq!(result.channels[0].id, "C024BE91L");
+        assert_eq!(result.groups[0].id, "G024BE91L");
+        assert_eq!(result.ims[0].id, "D024BFF1M");
+        assert_eq!(result.bots[0].id, "B87654321");
+    }
+}

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -1,0 +1,452 @@
+//! Search your team's files and messages.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SearchMatches<T> {
+    pub total: u32,
+    pub matches: Vec<T>,
+    pub paging: super::Pagination
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct MessageLink {
+    pub user: String,
+    pub username: String,
+    pub ts: String,
+    pub text: String
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SearchMessageChannel {
+    pub id: String,
+    pub name: String
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SearchMessage {
+    pub user: String,
+    pub username: String,
+    pub ts: String,
+    pub text: String,
+    pub channel: SearchMessageChannel,
+    pub permalink: String,
+    pub previous: Option<MessageLink>,
+    pub previous_2: Option<MessageLink>,
+    pub next: Option<MessageLink>,
+    pub next_2: Option<MessageLink>
+}
+
+/// Searches for messages and files matching a query.
+///
+/// Wraps https://api.slack.com/methods/search.all
+pub fn all(client: &hyper::Client, token: &str, query: &str, sort: Option<&str>, sort_dir: Option<&str>, highlight: Option<bool>, count: Option<u32>, page: Option<u32>) -> ApiResult<AllResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params = HashMap::new();
+    params.insert("query", query);
+    if let Some(sort) = sort {
+        params.insert("sort", sort);
+    }
+    if let Some(sort_dir) = sort_dir {
+        params.insert("sort_dir", sort_dir);
+    }
+    if let Some(highlight) = highlight {
+        params.insert("highlight", if highlight { "1" } else { "0" });
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "search.all", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AllResponse {
+    pub query: String,
+    pub messages: SearchMatches<SearchMessage>,
+    pub files: SearchMatches<super::File>
+}
+
+/// Searches for files matching a query.
+///
+/// Wraps https://api.slack.com/methods/search.files
+pub fn files(client: &hyper::Client, token: &str, query: &str, sort: Option<&str>, sort_dir: Option<&str>, highlight: Option<bool>, count: Option<u32>, page: Option<u32>) -> ApiResult<FilesResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params = HashMap::new();
+    params.insert("query", query);
+    if let Some(sort) = sort {
+        params.insert("sort", sort);
+    }
+    if let Some(sort_dir) = sort_dir {
+        params.insert("sort_dir", sort_dir);
+    }
+    if let Some(highlight) = highlight {
+        params.insert("highlight", if highlight { "1" } else { "0" });
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "search.files", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct FilesResponse {
+    pub query: String,
+    pub files: SearchMatches<super::File>
+}
+
+/// Searches for messages matching a query.
+///
+/// Wraps https://api.slack.com/methods/search.messages
+pub fn messages(client: &hyper::Client, token: &str, query: &str, sort: Option<&str>, sort_dir: Option<&str>, highlight: Option<bool>, count: Option<u32>, page: Option<u32>) -> ApiResult<MessagesResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params = HashMap::new();
+    params.insert("query", query);
+    if let Some(sort) = sort {
+        params.insert("sort", sort);
+    }
+    if let Some(sort_dir) = sort_dir {
+        params.insert("sort_dir", sort_dir);
+    }
+    if let Some(highlight) = highlight {
+        params.insert("highlight", if highlight { "1" } else { "0" });
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "search.messages", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct MessagesResponse {
+    pub query: String,
+    pub messages: SearchMatches<SearchMessage>
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = all(&client, "TEST_TOKEN", "pickleface", Some("timestamp"), Some("asc"), Some(true), Some(100), Some(1));
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockAllOkResponder, r#"
+        {
+            "ok": true,
+            "query": "Best Pickles",
+            "messages": {
+                "total": 1,
+                "matches": [
+                    {
+                        "type": "message",
+                        "channel": {
+                            "id": "C2147483753",
+                            "name": "foo"
+                        },
+                        "user": "U2147483709",
+                        "username": "johnnytest",
+                        "ts": "1359414002.000003",
+                        "text": "mention test: johnnyrodgers",
+                        "permalink": "https:\/\/example.slack.com\/channels\/foo\/p1359414002000003",
+                        "previous_2": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said before before",
+                            "ts": "1359413987.000000",
+                            "type": "message"
+                        },
+                        "previous": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said before",
+                            "ts": "1359414001.000000",
+                            "type": "message"
+                        },
+                        "next": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said after",
+                            "ts": "1359414020.000000",
+                            "type": "message"
+                        },
+                        "next_2": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said after after",
+                            "ts": "1359414021.000000",
+                            "type": "message"
+                        }
+                    }
+                ],
+                "paging": {
+                    "count": 100,
+                    "total": 15,
+                    "page": 1,
+                    "pages": 1
+                }
+            },
+            "files": {
+                "total": 1,
+                "matches": [
+                    {
+                        "id" : "F2147483862",
+                        "created" : 1356032811,
+                        "timestamp" : 1356032811,
+
+                        "name" : "file.htm",
+                        "title" : "My HTML file",
+                        "mimetype" : "text\/plain",
+                        "filetype" : "text",
+                        "pretty_type": "Text",
+                        "user" : "U2147483697",
+
+                        "mode" : "hosted",
+                        "editable" : true,
+                        "is_external": false,
+                        "external_type": "",
+
+                        "size" : 12345,
+
+                        "url": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/1.png",
+                        "url_download": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/download\/1.png",
+                        "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+                        "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+                        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+                        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+                        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+                        "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+                        "thumb_360_w": 100,
+                        "thumb_360_h": 100,
+
+                        "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+                        "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+                        "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+                        "preview_highlight" : "&lt;div class=\"sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+                        "lines" : 123,
+                        "lines_more": 118,
+
+                        "is_public": true,
+                        "public_url_shared": false,
+                        "channels": ["C024BE7LT"],
+                        "groups": ["G12345"],
+                        "ims": ["D12345"],
+                        "num_stars": 7,
+                        "is_starred": true,
+                        "pinned_to": ["C024BE7LT"],
+                        "reactions": [
+                            {
+                                "name": "astonished",
+                                "count": 3,
+                                "users": [ "U1", "U2", "U3" ]
+                            },
+                            {
+                                "name": "facepalm",
+                                "count": 1034,
+                                "users": [ "U1", "U2", "U3", "U4", "U5" ]
+                            }
+                        ]
+                    }
+                ],
+                "paging": {
+                    "count": 100,
+                    "total": 15,
+                    "page": 1,
+                    "pages": 1
+                }
+            }
+        }
+    "#);
+
+    #[test]
+    fn all_ok_response() {
+        let client = hyper::Client::with_connector(MockAllOkResponder::default());
+        let result = all(&client, "TEST_TOKEN", "pickleface", Some("timestamp"), Some("asc"), Some(true), Some(100), Some(1));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.messages.matches[0].user, "U2147483709");
+        assert_eq!(result.files.matches[0].id, "F2147483862");
+    }
+
+    mock_slack_responder!(MockFilesOkResponder, r#"
+        {
+            "ok": true,
+            "query": "Best Pickles",
+            "files": {
+                "total": 1,
+                "matches": [
+                    {
+                        "id" : "F2147483862",
+                        "created" : 1356032811,
+                        "timestamp" : 1356032811,
+
+                        "name" : "file.htm",
+                        "title" : "My HTML file",
+                        "mimetype" : "text\/plain",
+                        "filetype" : "text",
+                        "pretty_type": "Text",
+                        "user" : "U2147483697",
+
+                        "mode" : "hosted",
+                        "editable" : true,
+                        "is_external": false,
+                        "external_type": "",
+
+                        "size" : 12345,
+
+                        "url": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/1.png",
+                        "url_download": "https:\/\/slack-files.com\/files-pub\/T024BE7LD-F024BERPE-09acb6\/download\/1.png",
+                        "url_private": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/1.png",
+                        "url_private_download": "https:\/\/slack.com\/files-pri\/T024BE7LD-F024BERPE\/download\/1.png",
+
+                        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_64.png",
+                        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_80.png",
+                        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.png",
+                        "thumb_360_gif": "https:\/\/slack-files.com\/files-tmb\/T024BE7LD-F024BERPE-c66246\/1_360.gif",
+                        "thumb_360_w": 100,
+                        "thumb_360_h": 100,
+
+                        "permalink" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png",
+                        "edit_link" : "https:\/\/tinyspeck.slack.com\/files\/cal\/F024BERPE\/1.png/edit",
+                        "preview" : "&lt;!DOCTYPE html&gt;\n&lt;html&gt;\n&lt;meta charset='utf-8'&gt;",
+                        "preview_highlight" : "&lt;div class=\"sssh-code\"&gt;&lt;div class=\"sssh-line\"&gt;&lt;pre&gt;&lt;!DOCTYPE html...",
+                        "lines" : 123,
+                        "lines_more": 118,
+
+                        "is_public": true,
+                        "public_url_shared": false,
+                        "channels": ["C024BE7LT"],
+                        "groups": ["G12345"],
+                        "ims": ["D12345"],
+                        "num_stars": 7,
+                        "is_starred": true,
+                        "pinned_to": ["C024BE7LT"],
+                        "reactions": [
+                            {
+                                "name": "astonished",
+                                "count": 3,
+                                "users": [ "U1", "U2", "U3" ]
+                            },
+                            {
+                                "name": "facepalm",
+                                "count": 1034,
+                                "users": [ "U1", "U2", "U3", "U4", "U5" ]
+                            }
+                        ]
+                    }
+                ],
+                "paging": {
+                    "count": 100,
+                    "total": 15,
+                    "page": 1,
+                    "pages": 1
+                }
+            }
+        }
+    "#);
+
+    #[test]
+    fn files_ok_response() {
+        let client = hyper::Client::with_connector(MockFilesOkResponder::default());
+        let result = files(&client, "TEST_TOKEN", "pickleface", Some("timestamp"), Some("asc"), Some(true), Some(100), Some(1));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.files.matches[0].id, "F2147483862");
+    }
+
+    mock_slack_responder!(MockMessagesOkResponder, r#"
+        {
+            "ok": true,
+            "query": "Best Pickles",
+            "messages": {
+                "total": 1,
+                "matches": [
+                    {
+                        "type": "message",
+                        "channel": {
+                            "id": "C2147483753",
+                            "name": "foo"
+                        },
+                        "user": "U2147483709",
+                        "username": "johnnytest",
+                        "ts": "1359414002.000003",
+                        "text": "mention test: johnnyrodgers",
+                        "permalink": "https:\/\/example.slack.com\/channels\/foo\/p1359414002000003",
+                        "previous_2": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said before before",
+                            "ts": "1359413987.000000",
+                            "type": "message"
+                        },
+                        "previous": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said before",
+                            "ts": "1359414001.000000",
+                            "type": "message"
+                        },
+                        "next": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said after",
+                            "ts": "1359414020.000000",
+                            "type": "message"
+                        },
+                        "next_2": {
+                            "user": "U2147483709",
+                            "username": "johnnytest",
+                            "text": "This was said after after",
+                            "ts": "1359414021.000000",
+                            "type": "message"
+                        }
+                    }
+                ],
+                "paging": {
+                    "count": 100,
+                    "total": 15,
+                    "page": 1,
+                    "pages": 1
+                }
+            }
+        }
+    "#);
+
+    #[test]
+    fn messages_ok_response() {
+        let client = hyper::Client::with_connector(MockMessagesOkResponder::default());
+        let result = messages(&client, "TEST_TOKEN", "pickleface", Some("timestamp"), Some("asc"), Some(true), Some(100), Some(1));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().messages.matches[0].user, "U2147483709");
+    }
+}

--- a/src/api/stars.rs
+++ b/src/api/stars.rs
@@ -1,0 +1,210 @@
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Adds a star to an item.
+///
+/// Wraps https://api.slack.com/methods/stars.add
+pub fn add(client: &hyper::Client, token: &str, file: Option<&str>, file_comment: Option<&str>, channel: Option<&str>, timestamp: Option<&str>) -> ApiResult<AddResponse> {
+    let mut params = HashMap::new();
+    if let Some(file) = file {
+        params.insert("file", file);
+    }
+    if let Some(file_comment) = file_comment {
+        params.insert("file_comment", file_comment);
+    }
+    if let Some(channel) = channel {
+        params.insert("channel", channel);
+    }
+    if let Some(timestamp) = timestamp {
+        params.insert("timestamp", timestamp);
+    }
+    make_authed_api_call(client, "stars.add", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AddResponse;
+
+/// Lists stars for a user.
+///
+/// Wraps https://api.slack.com/methods/stars.list
+pub fn list(client: &hyper::Client, token: &str, user: Option<&str>, count: Option<u32>, page: Option<u32>) -> ApiResult<ListResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params = HashMap::new();
+    if let Some(user) = user {
+        params.insert("user", user);
+    }
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "stars.list", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub items: Vec<super::StarredItem>,
+    pub paging: super::Pagination
+}
+
+/// Removes a star from an item.
+///
+/// Wraps https://api.slack.com/methods/stars.remove
+pub fn remove(client: &hyper::Client, token: &str, file: Option<&str>, file_comment: Option<&str>, channel: Option<&str>, timestamp: Option<&str>) -> ApiResult<RemoveResponse> {
+    let mut params = HashMap::new();
+    if let Some(file) = file {
+        params.insert("file", file);
+    }
+    if let Some(file_comment) = file_comment {
+        params.insert("file_comment", file_comment);
+    }
+    if let Some(channel) = channel {
+        params.insert("channel", channel);
+    }
+    if let Some(timestamp) = timestamp {
+        params.insert("timestamp", timestamp);
+    }
+    make_authed_api_call(client, "stars.remove", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct RemoveResponse;
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+    use super::super::StarredItem;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = add(&client, "TEST_TOKEN", None, None, Some("TEST_CHANNEL"), Some("1234567890.123456"));
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockAddOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn add_ok_response() {
+        let client = hyper::Client::with_connector(MockAddOkResponder::default());
+        let result = add(&client, "TEST_TOKEN", None, None, Some("TEST_CHANNEL"), Some("1234567890.123456"));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockListOkResponder, r#"
+        {
+            "ok": true,
+            "items": [
+                {
+                    "type": "message",
+                    "channel": "C2147483705",
+                    "message": {
+                        "ts": "12345",
+                        "user": "123",
+                        "text": "something"
+                    }
+                },
+                {
+                    "type": "file",
+                    "file": {
+                        "id": "F12345678",
+                        "created": 1444929467,
+                        "timestamp": 1444929467,
+                        "name": "test_img.png",
+                        "title": "test_img",
+                        "mimetype": "image\/png",
+                        "filetype": "png",
+                        "pretty_type": "PNG",
+                        "user": "U12345678",
+                        "editable": false,
+                        "size": 16153,
+                        "mode": "hosted",
+                        "is_external": false,
+                        "external_type": "",
+                        "is_public": true,
+                        "public_url_shared": false,
+                        "display_as_bot": false,
+                        "username": "",
+                        "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                        "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                        "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                        "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                        "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                        "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                        "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                        "thumb_360_w": 360,
+                        "thumb_360_h": 28,
+                        "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                        "thumb_480_w": 480,
+                        "thumb_480_h": 37,
+                        "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                        "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                        "thumb_720_w": 720,
+                        "thumb_720_h": 56,
+                        "image_exif_rotation": 1,
+                        "original_w": 895,
+                        "original_h": 69,
+                        "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                        "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                        "channels": [
+                            "C12345678"
+                        ],
+                        "groups": [
+
+                        ],
+                        "ims": [
+
+                        ],
+                        "comments_count": 0
+                    }
+                },
+                {
+                    "type": "channel",
+                    "channel": "C2147483705"
+                }
+            ],
+            "paging": {
+                "count": 100,
+                "total": 15,
+                "page": 1,
+                "pages": 1
+            }
+        }
+    "#);
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN", None, None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        match result.unwrap().items[2] {
+            StarredItem::Channel { channel: ref c } => assert_eq!(c, "C2147483705"),
+            _ => panic!("Expected Channel")
+        }
+    }
+
+    mock_slack_responder!(MockRemoveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn remove_ok_response() {
+        let client = hyper::Client::with_connector(MockRemoveOkResponder::default());
+        let result = remove(&client, "TEST_TOKEN", None, None, Some("TEST_CHANNEL"), Some("1234567890.123456"));
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+}

--- a/src/api/team.rs
+++ b/src/api/team.rs
@@ -1,0 +1,173 @@
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Gets the access logs for the current team.
+///
+/// Wraps https://api.slack.com/methods/team.accessLogs
+pub fn access_logs(client: &hyper::Client, token: &str, count: Option<u32>, page: Option<u32>) -> ApiResult<AccessLogsResponse> {
+    let count = count.map(|c| c.to_string());
+    let page = page.map(|p| p.to_string());
+    let mut params: HashMap<&str, &str> = HashMap::new();
+    if let Some(ref count) = count {
+        params.insert("count", count);
+    }
+    if let Some(ref page) = page {
+        params.insert("page", page);
+    }
+    make_authed_api_call(client, "team.accessLogs", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct LoginInfo {
+    pub user_id: String,
+    pub username: String,
+    pub date_first: u32,
+    pub date_last: u32,
+    pub count: u32,
+    pub ip: String,
+    pub user_agent: String,
+    pub isp: String,
+    pub country: String,
+    pub region: String
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct AccessLogsResponse {
+    pub logins: Vec<LoginInfo>,
+    pub paging: super::Pagination
+}
+
+/// Gets information about the current team.
+///
+/// Wraps https://api.slack.com/methods/team.info
+pub fn info(client: &hyper::Client, token: &str) -> ApiResult<InfoResponse> {
+    make_authed_api_call(client, "team.info", token, HashMap::new())
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct IconInfo {
+    pub image_34: String,
+    pub image_44: String,
+    pub image_68: String,
+    pub image_88: String,
+    pub image_102: String,
+    pub image_132: String,
+    pub image_default: bool
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct TeamInfo {
+    pub id: String,
+    pub name: String,
+    pub domain: String,
+    pub email_domain: String,
+    pub icon: IconInfo
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct InfoResponse {
+    pub team: TeamInfo
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = access_logs(&client, "TEST_TOKEN", None, None);
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockAccessLogsOkResponder, r#"
+        {
+            "ok": true,
+            "logins": [
+                {
+                    "user_id": "U12345",
+                    "username": "bob",
+                    "date_first": 1422922864,
+                    "date_last": 1422922864,
+                    "count": 1,
+                    "ip": "127.0.0.1",
+                    "user_agent": "SlackWeb Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/41.0.2272.35 Safari\/537.36",
+                    "isp": "BigCo ISP",
+                    "country": "US",
+                    "region": "CA"
+                },
+                {
+                    "user_id": "U45678",
+                    "username": "alice",
+                    "date_first": 1422922493,
+                    "date_last": 1422922493,
+                    "count": 1,
+                    "ip": "127.0.0.1",
+                    "user_agent": "SlackWeb Mozilla\/5.0 (iPhone; CPU iPhone OS 8_1_3 like Mac OS X) AppleWebKit\/600.1.4 (KHTML, like Gecko) Version\/8.0 Mobile\/12B466 Safari\/600.1.4",
+                    "isp": "BigCo ISP",
+                    "country": "US",
+                    "region": "CA"
+                }
+            ],
+            "paging": {
+                "count": 100,
+                "total": 2,
+                "page": 1,
+                "pages": 1
+            }
+        }
+    "#);
+
+    #[test]
+    fn access_logs_ok_response() {
+        let client = hyper::Client::with_connector(MockAccessLogsOkResponder::default());
+        let result = access_logs(&client, "TEST_TOKEN", None, None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.logins[0].username, "bob");
+        assert_eq!(result.logins[1].username, "alice");
+    }
+
+    mock_slack_responder!(MockInfoOkResponder, r#"
+        {
+            "ok": true,
+            "team": {
+                "id": "T12345",
+                "name": "My Team",
+                "domain": "example",
+                "email_domain": "",
+                "icon": {
+                    "image_34": "https:\/\/...",
+                    "image_44": "https:\/\/...",
+                    "image_68": "https:\/\/...",
+                    "image_88": "https:\/\/...",
+                    "image_102": "https:\/\/...",
+                    "image_132": "https:\/\/...",
+                    "image_default": true
+                }
+            }
+        }
+    "#);
+
+    #[test]
+    fn info_ok_response() {
+        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
+        let result = info(&client, "TEST_TOKEN");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.team.name, "My Team");
+        assert_eq!(result.team.icon.image_default, true);
+    }
+}

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,0 +1,662 @@
+use rustc_serialize::{Decodable,Decoder};
+
+/// The `Reaction` object as found in the [`File`](https://api.slack.com/types/file) type and some
+/// [`Message`](https://api.slack.com/events/message) responses.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Reaction {
+    pub name: String,
+    pub count: u32,
+    pub users: Vec<String>
+}
+
+/// The `Comment` object as found in the [`File`](https://api.slack.com/types/file) type and the
+/// [`files.info`](https://api.slack.com/methods/files.info) response.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Comment {
+    pub id: String,
+    pub timestamp: u32,
+    pub user: String,
+    pub comment: String,
+    pub reactions: Option<Vec<Reaction>>
+}
+
+/// The Slack [`File`](https://api.slack.com/types/file) type.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct File {
+    pub id: String,
+    pub created: Option<u32>,
+    pub timestamp: Option<u32>,
+    pub name: Option<String>,
+    pub title: String,
+    pub mimetype: String,
+    pub filetype: String,
+    pub pretty_type: String,
+    pub user: String,
+    pub mode: String,
+    pub editable: bool,
+    pub is_external: bool,
+    pub external_type: String,
+    pub size: u32,
+    pub url: String,
+    pub url_download: Option<String>,
+    pub url_private: String,
+    pub url_private_download: String,
+    pub thumb_64: String,
+    pub thumb_80: String,
+    pub thumb_360: String,
+    pub thumb_360_gif: Option<String>,
+    pub thumb_360_w: u32,
+    pub thumb_360_h: u32,
+    pub permalink: String,
+    pub edit_link: Option<String>,
+    pub preview: Option<String>,
+    pub preview_highlight: Option<String>,
+    pub lines: Option<u32>,
+    pub lines_more: Option<u32>,
+    pub is_public: bool,
+    pub public_url_shared: bool,
+    pub channels: Vec<String>,
+    pub groups: Vec<String>,
+    pub ims: Option<Vec<String>>,
+    pub initial_comment: Option<Comment>,
+    pub num_stars: Option<u32>,
+    pub is_starred: Option<bool>,
+    pub pinned_to: Option<Vec<String>>,
+    pub reactions: Option<Vec<Reaction>>
+}
+
+/// The `Paging` object as found in API endpoints that return pages of items.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Pagination {
+    pub count: u32,
+    pub total: u32,
+    pub page: u32,
+    pub pages: u32
+}
+
+/// The Slack [`Channel`](https://api.slack.com/types/channel) type.
+// Currently missing "latest" field
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Channel {
+    pub id: String,
+    pub name: String,
+    pub is_channel: bool,
+    pub created: i64,
+    pub creator: String,
+    pub is_archived: bool,
+    pub is_general: bool,
+    pub members: Option<Vec<String>>,
+    pub topic: Option<Topic>,
+    pub purpose: Option<Purpose>,
+    pub is_member: bool,
+    pub last_read: Option<String>,
+    pub unread_count: Option<i64>,
+    pub unread_count_display: Option<i64>,
+}
+
+/// The Slack [`Group`](https://api.slack.com/types/group) type.
+// Currently missing "latest" field
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Group {
+    pub id: String,
+    pub name: String,
+    pub is_group: bool,
+    pub created: i64,
+    pub creator:  String,
+    pub is_archived:  bool,
+    pub members: Option<Vec<String>>,
+    pub topic: Option<Topic>,
+    pub purpose: Option<Purpose>,
+    pub last_read: Option<String>,
+    pub unread_count: Option<i64>,
+    pub unread_count_display: Option<i64>,
+}
+
+/// The Profile that belongs to a [`User`](https://api.slack.com/types/user).
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct UserProfile {
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub real_name: Option<String>,
+    pub email: Option<String>,
+    pub skype: Option<String>,
+    pub phone: Option<String>,
+    pub image_24: String,
+    pub image_32: String,
+    pub image_48: String,
+    pub image_72: String,
+    pub image_192: String
+}
+
+/// The Slack [`User`](https://api.slack.com/types/user) type.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct User {
+    pub id: String,
+    pub name: String,
+    pub deleted: bool,
+    pub color: String,
+    pub profile: UserProfile,
+    pub is_admin: Option<bool>,
+    pub is_owner: Option<bool>,
+    pub is_primary_owner: Option<bool>,
+    pub is_restricted: Option<bool>,
+    pub is_ultra_restricted: Option<bool>,
+    pub has_2fa: Option<bool>,
+    pub two_factor_type: Option<String>,
+    pub has_files: Option<bool>
+}
+
+/// The `Team` object as found in the [`rtm.start`](https://api.slack.com/methods/rtm.start)
+/// response.
+// We've left out the prefs field for now
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Team {
+    pub id: String,
+    pub name: String,
+    pub email_domain: String,
+    pub domain: String,
+    pub msg_edit_window_mins: i64,
+    pub over_storage_limit: bool,
+    pub plan: String,
+}
+
+/// The `Topic` object as found in the [`Group`](https://api.slack.com/types/group) and
+/// [`Channel`](https://api.slack.com/types/channel) types.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Topic {
+    pub value: String,
+    pub creator: String,
+    pub last_set: i64,
+}
+
+/// The `Purpose` object as found in the [`Group`](https://api.slack.com/types/group) and
+/// [`Channel`](https://api.slack.com/types/channel) types.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Purpose {
+    pub value: String,
+    pub creator: String,
+    pub last_set: i64,
+}
+
+/// The Slack [`Im`](https://api.slack.com/types/im) type.
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct Im {
+    pub id: String,
+    pub is_im: bool,
+    pub user:  String,
+    pub created: i64,
+    pub is_user_deleted: Option<bool>,
+}
+
+/// A field within an [`Attachment`](https://api.slack.com/docs/attachments).
+#[derive(Clone,Debug,RustcDecodable,RustcEncodable)]
+pub struct AttachmentField {
+    pub title: String,
+    pub value: String,
+    pub short: bool
+}
+
+/// The Slack [`Attachment`](https://api.slack.com/docs/attachments) object as found in
+/// richly-formatted messages.
+#[derive(Clone,Debug,RustcDecodable,RustcEncodable)]
+pub struct Attachment {
+    pub fallback: String,
+    pub color: Option<String>,
+    pub pretext: Option<String>,
+    pub author_name: Option<String>,
+    pub author_link: Option<String>,
+    pub author_icon: Option<String>,
+    pub title: Option<String>,
+    pub title_link: Option<String>,
+    pub text: String,
+    pub fields: Option<Vec<AttachmentField>>,
+    pub image_url: Option<String>,
+    pub thumb_url: Option<String>
+}
+
+/// Represents a `Message`, `File` or `Comment` as returned by
+/// [`pins.list`](https://api.slack.com/methods/pins.list),
+/// [`reactions.list`](https://api.slack.com/methods/reactions.list), and
+/// [`reactions.get`](https://api.slack.com/methods/reactions.get).
+#[derive(Clone,Debug)]
+pub enum Item {
+    Message { channel: String, message: Box<super::MessageEvent> },
+    File { file: File },
+    FileComment { file: File, comment: Comment }
+}
+
+impl Decodable for Item {
+    fn decode<D: Decoder>(d: &mut D) -> Result<Item, D::Error> {
+        d.read_struct("item", 0, |d| {
+            let ty: String = try!(d.read_struct_field("type", 0, |d| Decodable::decode(d)));
+            if ty == "message" {
+                Ok(Item::Message {
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "file" {
+                Ok(Item::File {
+                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "file_comment" {
+                Ok(Item::FileComment {
+                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                    comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d)))
+                })
+            } else {
+                Err(d.error(&format!("Unknown Item type: {}", ty)))
+            }
+        })
+    }
+}
+
+/// Represents a starred item as returned by [`stars.list`](https://api.slack.com/methods/stars.list).
+// The Message, File and FileComment variants are the same as the ones in `super::Item`. However,
+// stars can be applied to channels, groups and ims as well, so we need a new enum to support those
+// options.
+#[derive(Clone,Debug)]
+pub enum StarredItem {
+    Message { channel: String, message: super::MessageEvent},
+    File { file: super::File },
+    FileComment { file: super::File, comment: super::Comment },
+    Channel { channel: String },
+    Group { group: String },
+    Im { channel: String }
+}
+
+impl Decodable for StarredItem {
+    fn decode<D: Decoder>(d: &mut D) -> Result<StarredItem, D::Error> {
+        d.read_struct("item", 0, |d| {
+            let ty: String = try!(d.read_struct_field("type", 0, |d| Decodable::decode(d)));
+            if ty == "message" {
+                Ok(StarredItem::Message {
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                    message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "file" {
+                Ok(StarredItem::File {
+                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "file_comment" {
+                Ok(StarredItem::FileComment {
+                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                    comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d)))
+                })
+            } else if ty == "channel" {
+                Ok(StarredItem::Channel {
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                })
+            } else if ty == "group" {
+                Ok(StarredItem::Group {
+                    group: try!(d.read_struct_field("group", 0, |d| Decodable::decode(d))),
+                })
+            } else if ty == "im" {
+                Ok(StarredItem::Im {
+                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                })
+            } else {
+                Err(d.error(&format!("Unknown StarredItem type: {}", ty)))
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::MessageEvent;
+    use super::*;
+    use rustc_serialize::json;
+
+    #[test]
+    fn item_message_decode() {
+        let item: Item = json::decode(r#"{
+            "type": "message",
+            "channel": "C2147483705",
+            "message": {
+                "ts": "12345",
+                "user": "123",
+                "text": "something"
+            }
+        }"#).unwrap();
+        match item {
+            Item::Message { channel: c, message: m } => {
+                assert_eq!(c, "C2147483705");
+                match *m.clone() {
+                    MessageEvent::Standard { ts: _, channel: _, user, text: _, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                        assert_eq!(user.unwrap(), "123")
+                    },
+                    _ => panic!("Message decoded into incorrect variant.")
+                }
+            },
+            _ => panic!("Item decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn item_file_decode() {
+        let item: Item = json::decode(r#"{
+            "type": "file",
+            "file": {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            }
+        }"#).unwrap();
+        match item {
+            Item::File { file: f } => {
+                assert_eq!(f.id, "F12345678");
+            },
+            _ => panic!("Item decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn item_file_comment_decode() {
+        let item: Item = json::decode(r#"{
+            "type": "file_comment",
+            "file": {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            },
+            "comment": {
+                "id": "Fc12345678",
+                "timestamp": 1356032811,
+                "user": "U12345678",
+                "comment": "This is a comment"
+            }
+        }"#).unwrap();
+        match item {
+            Item::FileComment { file: f, comment: c } => {
+                assert_eq!(f.id, "F12345678");
+                assert_eq!(c.id, "Fc12345678");
+            },
+            _ => panic!("Item decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn starred_item_message_decode() {
+        let item: StarredItem = json::decode(r#"{
+            "type": "message",
+            "channel": "C2147483705",
+            "message": {
+                "ts": "12345",
+                "user": "123",
+                "text": "something"
+            }
+        }"#).unwrap();
+        match item {
+            StarredItem::Message { channel: c, message: m } => {
+                assert_eq!(c, "C2147483705");
+                match m.clone() {
+                    MessageEvent::Standard { ts: _, channel: _, user, text: _, is_starred: _, pinned_to: _, reactions: _, edited: _, attachments: _ } => {
+                        assert_eq!(user.unwrap(), "123");
+                    },
+                    _ => panic!("Message decoded into incorrect variant.")
+                }
+            },
+            _ => panic!("StarredItem decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn starred_item_file_decode() {
+        let item: StarredItem = json::decode(r#"{
+            "type": "file",
+            "file": {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            }
+        }"#).unwrap();
+        match item {
+            StarredItem::File { file: f } => {
+                assert_eq!(f.id, "F12345678");
+            },
+            _ => panic!("StarredItem decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn starred_item_file_comment_decode() {
+        let item: StarredItem = json::decode(r#"{
+            "type": "file_comment",
+            "file": {
+                "id": "F12345678",
+                "created": 1444929467,
+                "timestamp": 1444929467,
+                "name": "test_img.png",
+                "title": "test_img",
+                "mimetype": "image\/png",
+                "filetype": "png",
+                "pretty_type": "PNG",
+                "user": "U12345678",
+                "editable": false,
+                "size": 16153,
+                "mode": "hosted",
+                "is_external": false,
+                "external_type": "",
+                "is_public": true,
+                "public_url_shared": false,
+                "display_as_bot": false,
+                "username": "",
+                "url": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/test_img.png",
+                "url_download": "https:\/\/slack-files.com\/files-pub\/PUBLIC-TEST-GUID\/download\/test_img.png",
+                "url_private": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/test_img.png",
+                "url_private_download": "https:\/\/files.slack.com\/files-pri\/PRIVATE-ID\/download\/test_img.png",
+                "thumb_64": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_64.png",
+                "thumb_80": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_80.png",
+                "thumb_360": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_360.png",
+                "thumb_360_w": 360,
+                "thumb_360_h": 28,
+                "thumb_480": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_480.png",
+                "thumb_480_w": 480,
+                "thumb_480_h": 37,
+                "thumb_160": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_160.png",
+                "thumb_720": "https:\/\/slack-files.com\/files-tmb\/PRIVATE-TEST-GUID\/test_img_720.png",
+                "thumb_720_w": 720,
+                "thumb_720_h": 56,
+                "image_exif_rotation": 1,
+                "original_w": 895,
+                "original_h": 69,
+                "permalink": "https:\/\/test-team.slack.com\/files\/testuser\/F12345678\/test_img.png",
+                "permalink_public": "https:\/\/slack-files.com\/PUBLIC-TEST-GUID",
+                "channels": [
+                    "C12345678"
+                ],
+                "groups": [
+
+                ],
+                "ims": [
+
+                ],
+                "comments_count": 0
+            },
+            "comment": {
+                "id": "Fc12345678",
+                "timestamp": 1356032811,
+                "user": "U12345678",
+                "comment": "This is a comment"
+            }
+        }"#).unwrap();
+        match item {
+            StarredItem::FileComment { file: f, comment: c } => {
+                assert_eq!(f.id, "F12345678");
+                assert_eq!(c.id, "Fc12345678");
+            },
+            _ => panic!("StarredItem decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn starred_item_channel_decode() {
+        let item: StarredItem = json::decode(r#"{"type": "channel", "channel": "C12345678"}"#).unwrap();
+        match item {
+            StarredItem::Channel { channel: c } => {
+                assert_eq!(c, "C12345678");
+            },
+            _ => panic!("StarredItem decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn starred_item_group_decode() {
+        let item: StarredItem = json::decode(r#"{"type": "group", "group": "G12345678"}"#).unwrap();
+        match item {
+            StarredItem::Group { group: g } => {
+                assert_eq!(g, "G12345678");
+            },
+            _ => panic!("StarredItem decoded into incorrect variant.")
+        };
+    }
+
+    #[test]
+    fn starred_item_im_decode() {
+        let item: StarredItem = json::decode(r#"{"type": "im", "channel": "D12345678"}"#).unwrap();
+        match item {
+            StarredItem::Im { channel: c } => {
+                assert_eq!(c, "D12345678");
+            },
+            _ => panic!("StarredItem decoded into incorrect variant.")
+        };
+    }
+}

--- a/src/api/users.rs
+++ b/src/api/users.rs
@@ -1,0 +1,265 @@
+//! Get info on members of your Slack team.
+//!
+//! For more information, see [Slack's API documentation](https://api.slack.com/methods).
+
+use std::collections::HashMap;
+use hyper;
+
+use super::ApiResult;
+use super::make_authed_api_call;
+
+/// Gets user presence information.
+///
+/// Wraps https://api.slack.com/methods/users.getPresence
+pub fn get_presence(client: &hyper::Client, token: &str, user: &str) -> ApiResult<GetPresenceResponse> {
+    let mut params = HashMap::new();
+    params.insert("user", user);
+    make_authed_api_call(client, "users.getPresence", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct GetPresenceResponse {
+    pub presence: String,
+    pub online: Option<bool>,
+    pub auto_away: Option<bool>,
+    pub manual_away: Option<bool>,
+    pub connection_count: Option<u32>,
+    pub last_activity: Option<u32>
+}
+
+/// Gets information about a user.
+///
+/// Wraps https://api.slack.com/methods/users.info
+pub fn info(client: &hyper::Client, token: &str, user: &str) -> ApiResult<InfoResponse> {
+    let mut params = HashMap::new();
+    params.insert("user", user);
+    make_authed_api_call(client, "users.info", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct InfoResponse {
+    pub user: super::User
+}
+
+/// Lists all users in a Slack team.
+///
+/// Wraps https://api.slack.com/methods/users.list
+pub fn list(client: &hyper::Client, token: &str, presence: Option<bool>) -> ApiResult<ListResponse> {
+    let mut params = HashMap::new();
+    if let Some(presence) = presence {
+        params.insert("presence", if presence { "1" } else { "0" });
+    }
+    make_authed_api_call(client, "users.list", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct ListResponse {
+    pub members: Vec<super::User>
+}
+
+/// Marks a user as active.
+///
+/// Wraps https://api.slack.com/methods/users.setActive
+pub fn set_active(client: &hyper::Client, token: &str) -> ApiResult<SetActiveResponse> {
+    make_authed_api_call(client, "users.setActive", token, HashMap::new())
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SetActiveResponse;
+
+/// Manually sets user presence.
+///
+/// Wraps https://api.slack.com/methods/users.setPresence
+pub fn set_presence(client: &hyper::Client, token: &str, presence: &str) -> ApiResult<SetPresenceResponse> {
+    let mut params = HashMap::new();
+    params.insert("presence", presence);
+    make_authed_api_call(client, "users.setPresence", token, params)
+}
+
+#[derive(Clone,Debug,RustcDecodable)]
+pub struct SetPresenceResponse;
+
+#[cfg(test)]
+mod tests {
+    use hyper;
+    use super::*;
+
+    mock_slack_responder!(MockErrorResponder, r#"{"ok": false, "err": "some_error"}"#);
+
+    #[test]
+    fn general_api_error_response() {
+        let client = hyper::Client::with_connector(MockErrorResponder::default());
+        let result = get_presence(&client, "TEST_TOKEN", "U12345678");
+        assert!(result.is_err());
+    }
+
+    mock_slack_responder!(MockGetPresenceOkResponder, r#"
+        {
+            "ok": true,
+            "presence": "active"
+        }
+    "#);
+
+    #[test]
+    fn get_presence_ok_response() {
+        let client = hyper::Client::with_connector(MockGetPresenceOkResponder::default());
+        let result = get_presence(&client, "TEST_TOKEN", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        assert_eq!(result.unwrap().presence, "active");
+    }
+
+    mock_slack_responder!(MockGetPresenceAuthedUserOkResponder, r#"
+        {
+            "ok": true,
+            "presence": "active",
+            "online": true,
+            "auto_away": false,
+            "manual_away": false,
+            "connection_count": 1,
+            "last_activity": 1419027078
+        }
+    "#);
+
+    #[test]
+    fn get_presence_authed_user_ok_response() {
+        let client = hyper::Client::with_connector(MockGetPresenceAuthedUserOkResponder::default());
+        let result = get_presence(&client, "TEST_TOKEN", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.presence, "active");
+        assert_eq!(result.last_activity.unwrap(), 1419027078);
+    }
+
+    mock_slack_responder!(MockInfoOkResponder, r#"
+        {
+            "ok": true,
+            "user": {
+                "id": "U023BECGF",
+                "name": "bobby",
+                "deleted": false,
+                "color": "9f69e7",
+                "profile": {
+                    "first_name": "Bobby",
+                    "last_name": "Tables",
+                    "real_name": "Bobby Tables",
+                    "email": "bobby@slack.com",
+                    "skype": "my-skype-name",
+                    "phone": "+1 (123) 456 7890",
+                    "image_24": "https:\/\/...",
+                    "image_32": "https:\/\/...",
+                    "image_48": "https:\/\/...",
+                    "image_72": "https:\/\/...",
+                    "image_192": "https:\/\/..."
+                },
+                "is_admin": true,
+                "is_owner": true,
+                "has_2fa": true,
+                "has_files": true
+            }
+        }
+    "#);
+
+    #[test]
+    fn info_ok_response() {
+        let client = hyper::Client::with_connector(MockInfoOkResponder::default());
+        let result = info(&client, "TEST_TOKEN", "U12345678");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.user.id, "U023BECGF");
+        assert_eq!(result.user.profile.email.as_ref().unwrap(), "bobby@slack.com");
+    }
+
+    mock_slack_responder!(MockListOkResponder, r#"
+        {
+            "ok": true,
+            "members": [
+                {
+                    "id": "U023BECGF",
+                    "name": "bobby",
+                    "deleted": false,
+                    "color": "9f69e7",
+                    "profile": {
+                        "first_name": "Bobby",
+                        "last_name": "Tables",
+                        "real_name": "Bobby Tables",
+                        "email": "bobby@slack.com",
+                        "skype": "my-skype-name",
+                        "phone": "+1 (123) 456 7890",
+                        "image_24": "https:\/\/...",
+                        "image_32": "https:\/\/...",
+                        "image_48": "https:\/\/...",
+                        "image_72": "https:\/\/...",
+                        "image_192": "https:\/\/..."
+                    },
+                    "is_admin": true,
+                    "is_owner": true,
+                    "has_2fa": true,
+                    "has_files": true
+                },
+                {
+                    "id": "U12345678",
+                    "name": "alice",
+                    "deleted": false,
+                    "color": "9f69e7",
+                    "profile": {
+                        "first_name": "Alice",
+                        "last_name": "Aardvark",
+                        "real_name": "Alice Aardvark",
+                        "email": "alice@slack.com",
+                        "skype": "my-skype-name",
+                        "phone": "+1 (123) 456 7890",
+                        "image_24": "https:\/\/...",
+                        "image_32": "https:\/\/...",
+                        "image_48": "https:\/\/...",
+                        "image_72": "https:\/\/...",
+                        "image_192": "https:\/\/..."
+                    },
+                    "is_admin": true,
+                    "is_owner": true,
+                    "has_2fa": true,
+                    "has_files": true
+                }
+            ]
+        }
+    "#);
+
+    #[test]
+    fn list_ok_response() {
+        let client = hyper::Client::with_connector(MockListOkResponder::default());
+        let result = list(&client, "TEST_TOKEN", None);
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+        let result = result.unwrap();
+        assert_eq!(result.members[1].id, "U12345678");
+        assert_eq!(result.members[0].profile.email.as_ref().unwrap(), "bobby@slack.com");
+    }
+
+    mock_slack_responder!(MockSetActiveOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn set_active_ok_response() {
+        let client = hyper::Client::with_connector(MockSetActiveOkResponder::default());
+        let result = set_active(&client, "TEST_TOKEN");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+
+    mock_slack_responder!(MockSetPresenceOkResponder, r#"{"ok": true}"#);
+
+    #[test]
+    fn set_presence_ok_response() {
+        let client = hyper::Client::with_connector(MockSetPresenceOkResponder::default());
+        let result = set_presence(&client, "TEST_TOKEN", "active");
+        if let Err(err) = result {
+            panic!(format!("{:?}", err));
+        }
+    }
+}


### PR DESCRIPTION
This is it! All of the Slack web API endpoints have been wrapped. However, there are still a few outstanding issues that **should be resolved before this gets merged** or at the very least least tracked to get resolved after merging.

- [x] ~~No endpoints are tested except for `channels.*`, `api.*` and `auth.*`. [**In Progress**](https://github.com/BenTheElder/slack-rs/pull/17#issuecomment-148960255)~~
- [ ] `files.upload` is left unimplemented. This requires pulling in other dependencies (namely [`multipart`](https://crates.io/crates/multipart)), but the dependencies require some TLC to work with what we have going on.
- [x] ~~Some of the parameters still take `Option<&str>` when an `Option<bool>` (or just `bool`?) or `Option<u32>` or some other more strongly-typed value would be more appropriate. Still trying to figure out how to work with this, because `Option<u32>` in particular does not want to play nice.~~
- [x] ~~Weak documentation~~
- [x] Still a few response values that don't perfectly line up with the actual returned value. ~~In particular, there are some responses that return a list of heterogeneous "`Item`"s, which I'm not sure what to do with yet.~~ There are also some responses that have a field called `type`, which is a keyword and requires a custom decoder like `RtmStart`/`rtm::StartResponse`.
- [x] General cleanup and code consistency pass
- [x] ~~Still have the `mock.rs` module from `hyper`. I want to remove this. Looking into either using [`yup-hyper-mock`](https://crates.io/crates/yup-hyper-mock) or seeing if `hyper` can expose the `mock` module itself.~~

The commits in this PR will get squashed prior to merge. 

**I welcome any feedback/criticism/bikeshedding!**