### PR TITLE
close child properly and timeout after 70 seconds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,6 +489,7 @@ impl RtmClient {
                 Err(err) => {
                     // shutdown sender and receiver, then join the child thread
                     // and return an error.
+                    let _ = tx.send(WsMessage::Close);
                     let _ = receiver.shutdown_all();
                     let _ = child.join();
                     return Err(Error::Internal(format!("{:?}", err)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,6 +479,17 @@ impl RtmClient {
             }
         });
 
+        // set receive timeout long enough for slack ping
+        {
+            let read_timeout = std::time::Duration::from_secs(70);
+            let mut ws_stream = receiver.get_mut().get_mut();
+            let tcp_stream: &mut std::net::TcpStream = match ws_stream {
+                &mut WebSocketStream::Tcp(ref mut s) => s,
+                &mut WebSocketStream::Ssl(ref mut s) => s.get_mut(),
+            };
+            try!(tcp_stream.set_read_timeout(Some(read_timeout)));
+        }
+
         // receive loop
         loop {
             // receive


### PR DESCRIPTION
Adding timeout and properly joining the child thread results in a propagating error when no ping was received within 70 seconds