### PR TITLE
Added reconnect_url and changed API to use match rather than if/else

### DIFF
--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -347,167 +347,220 @@ impl Decodable for Event {
     fn decode<D: Decoder>(d: &mut D) -> Result<Event, D::Error> {
         let ty: String = try!(d.read_struct_field("type", 0, |d| Decodable::decode(d)));
         match ty.as_ref() {
-        "hello" => Ok(Event::Hello),
-        "message" => Ok(Event::Message(try!(super::Message::decode(d)))),
-        "user_typing" => Ok(Event::UserTyping {
+            "hello" => Ok(Event::Hello),
+            "message" => Ok(Event::Message(try!(super::Message::decode(d)))),
+            "user_typing" => Ok(Event::UserTyping {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
             }),
-        "channel_marked" => Ok(Event::ChannelMarked {
+            "channel_marked" => Ok(Event::ChannelMarked {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
             }),
-        "channel_created" => Ok(Event::ChannelCreated { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "channel_joined" => Ok(Event::ChannelJoined { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "channel_left" => Ok(Event::ChannelLeft { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "channel_deleted" => Ok(Event::ChannelDeleted { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "channel_rename" => Ok(Event::ChannelRename { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "channel_archive" => Ok(Event::ChannelArchive {
+            "channel_created" => Ok(Event::ChannelCreated {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "channel_joined" => Ok(Event::ChannelJoined {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "channel_left" => Ok(Event::ChannelLeft {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "channel_deleted" => Ok(Event::ChannelDeleted {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "channel_rename" => Ok(Event::ChannelRename {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "channel_archive" => Ok(Event::ChannelArchive {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
             }),
-        "channel_unarchive" => Ok(Event::ChannelUnArchive {
+            "channel_unarchive" => Ok(Event::ChannelUnArchive {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
             }),
-        "channel_history_changed" => Ok(Event::ChannelHistoryChanged {
+            "channel_history_changed" => Ok(Event::ChannelHistoryChanged {
                 latest: try!(d.read_struct_field("latest", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "im_created" => Ok(Event::ImCreated {
+            "im_created" => Ok(Event::ImCreated {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
             }),
-        "im_open" => Ok(Event::ImOpen {
+            "im_open" => Ok(Event::ImOpen {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
             }),
-        "im_close" => Ok(Event::ImClose {
+            "im_close" => Ok(Event::ImClose {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
             }),
-        "im_marked" => Ok(Event::ImMarked {
+            "im_marked" => Ok(Event::ImMarked {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
             }),
-        "im_history_changed" => Ok(Event::ImHistoryChanged {
+            "im_history_changed" => Ok(Event::ImHistoryChanged {
                 latest: try!(d.read_struct_field("latest", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "group_joined" => Ok(Event::GroupJoined { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "group_left" => Ok(Event::GroupLeft { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "group_open" => Ok(Event::GroupOpen {
+            "group_joined" => Ok(Event::GroupJoined {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "group_left" => Ok(Event::GroupLeft {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "group_open" => Ok(Event::GroupOpen {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
             }),
-        "group_close" => Ok(Event::GroupClose {
+            "group_close" => Ok(Event::GroupClose {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
             }),
-        "group_archive" => Ok(Event::GroupArchive { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "group_unarchive" => Ok(Event::GroupUnArchive { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "group_rename" => Ok(Event::GroupRename { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
-        "group_marked" => Ok(Event::GroupMarked {
+            "group_archive" => Ok(Event::GroupArchive {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "group_unarchive" => Ok(Event::GroupUnArchive {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "group_rename" => Ok(Event::GroupRename {
+                channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+            }),
+            "group_marked" => Ok(Event::GroupMarked {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
             }),
-        "group_history_changed" => Ok(Event::GroupHistoryChanged {
+            "group_history_changed" => Ok(Event::GroupHistoryChanged {
                 latest: try!(d.read_struct_field("latest", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
             }),
-        "file_created" => Ok(Event::FileCreated { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
-        "file_shared" => Ok(Event::FileShared { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
-        "file_unshared" => Ok(Event::FileUnShared { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
-        "file_public" => Ok(Event::FilePublic { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
-        "file_private" => Ok(Event::FilePrivate { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
-        "file_change" => Ok(Event::FileChange { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
-        "file_deleted" => Ok(Event::FileDeleted {
+            "file_created" => Ok(Event::FileCreated {
+                file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+            }),
+            "file_shared" => Ok(Event::FileShared {
+                file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+            }),
+            "file_unshared" => Ok(Event::FileUnShared {
+                file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+            }),
+            "file_public" => Ok(Event::FilePublic {
+                file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+            }),
+            "file_private" => Ok(Event::FilePrivate {
+                file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+            }),
+            "file_change" => Ok(Event::FileChange {
+                file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+            }),
+            "file_deleted" => Ok(Event::FileDeleted {
                 file_id: try!(d.read_struct_field("file_id", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "file_comment_added" => Ok(Event::FileCommentAdded {
+            "file_comment_added" => Ok(Event::FileCommentAdded {
                 file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
                 comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
             }),
-        "file_comment_edited" => Ok(Event::FileCommentEdited {
+            "file_comment_edited" => Ok(Event::FileCommentEdited {
                 file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
                 comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
             }),
-        "file_comment_deleted" => Ok(Event::FileCommentDeleted {
+            "file_comment_deleted" => Ok(Event::FileCommentDeleted {
                 file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
                 comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
             }),
-        "pin_added" => Ok(Event::PinAdded {
+            "pin_added" => Ok(Event::PinAdded {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel_id: try!(d.read_struct_field("channel_id", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "pin_removed" => Ok(Event::PinRemoved {
+            "pin_removed" => Ok(Event::PinRemoved {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel_id: try!(d.read_struct_field("channel_id", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 has_pins: try!(d.read_struct_field("has_pins", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "presence_change" => Ok(Event::PresenceChange {
+            "presence_change" => Ok(Event::PresenceChange {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 presence: try!(d.read_struct_field("presence", 0, |d| Decodable::decode(d))),
             }),
-        "manual_presence_change" => Ok(Event::ManualPresenceChange { presence: try!(d.read_struct_field("presence", 0, |d| Decodable::decode(d))) }),
-        "pref_change" => Ok(Event::PrefChange {
+            "manual_presence_change" => Ok(Event::ManualPresenceChange {
+                presence: try!(d.read_struct_field("presence", 0, |d| Decodable::decode(d))),
+            }),
+            "pref_change" => Ok(Event::PrefChange {
                 name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
                 value: try!(d.read_struct_field("value", 0, |d| Decodable::decode(d))),
             }),
-        "user_change" => Ok(Event::UserChange { user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))) }),
-        "team_join" => Ok(Event::TeamJoin { user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))) }),
-        "star_added" => Ok(Event::StarAdded {
+            "user_change" => Ok(Event::UserChange {
+                user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+            }),
+            "team_join" => Ok(Event::TeamJoin {
+                user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+            }),
+            "star_added" => Ok(Event::StarAdded {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "star_removed" => Ok(Event::StarRemoved {
+            "star_removed" => Ok(Event::StarRemoved {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "reaction_added" => Ok(Event::ReactionAdded {
-                user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
-                item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
-                event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            }),
-        "reaction_removed" => Ok(Event::ReactionRemoved {
+            "reaction_added" => Ok(Event::ReactionAdded {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
             }),
-        "emoji_changed" => Ok(Event::EmojiChanged { event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))) }),
-        "commands_changed" => Ok(Event::CommandsChanged { event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))) }),
-        "team_plan_change" => Ok(Event::TeamPlanChange { plan: try!(d.read_struct_field("plan", 0, |d| Decodable::decode(d))) }),
-        "team_pref_change" => Ok(Event::TeamPrefChange {
+            "reaction_removed" => Ok(Event::ReactionRemoved {
+                user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
+                item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
+                event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
+            }),
+            "emoji_changed" => Ok(Event::EmojiChanged {
+                event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
+            }),
+            "commands_changed" => Ok(Event::CommandsChanged {
+                event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
+            }),
+            "team_plan_change" => Ok(Event::TeamPlanChange {
+                plan: try!(d.read_struct_field("plan", 0, |d| Decodable::decode(d))),
+            }),
+            "team_pref_change" => Ok(Event::TeamPrefChange {
                 name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
                 value: try!(d.read_struct_field("value", 0, |d| Decodable::decode(d))),
             }),
-        "team_rename" => Ok(Event::TeamRename { name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))) }),
-        "team_domain_change" => Ok(Event::TeamDomainChange {
+            "team_rename" => Ok(Event::TeamRename {
+                name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
+            }),
+            "team_domain_change" => Ok(Event::TeamDomainChange {
                 url: try!(d.read_struct_field("url", 0, |d| Decodable::decode(d))),
                 domain: try!(d.read_struct_field("domain", 0, |d| Decodable::decode(d))),
             }),
-        "email_domain_changeed" => Ok(Event::EmailDomainChanged {
-                email_domain: try!(d.read_struct_field("email_domain", 0, |d| Decodable::decode(d))),
-                event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
+            "email_domain_changeed" =>
+                Ok(Event::EmailDomainChanged {
+                    email_domain: try!(d.read_struct_field("email_domain",
+                                                           0,
+                                                           |d| Decodable::decode(d))),
+                    event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
+                }),
+            "bot_added" => Ok(Event::BotAdded {
+                bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))),
             }),
-        "bot_added" => Ok(Event::BotAdded { bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))) }),
-        "bot_changed" => Ok(Event::BotChanged { bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))) }),
-        "accounts_changed" => Ok(Event::AccountsChanged),
-        "team_migration_started" => Ok(Event::TeamMigrationStarted),
-        "reconnect_url" => Ok(Event::ReconnectUrl),
-        _ => Err(d.error(&format!("Unknown Message type: {}", ty)))
+            "bot_changed" => Ok(Event::BotChanged {
+                bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))),
+            }),
+            "accounts_changed" => Ok(Event::AccountsChanged),
+            "team_migration_started" => Ok(Event::TeamMigrationStarted),
+            "reconnect_url" => Ok(Event::ReconnectUrl),
+            _ => Err(d.error(&format!("Unknown Message type: {}", ty))),
         }
     }
 }

--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -337,6 +337,10 @@ pub enum Event {
     /// [`team_migration_started`](https://api.slack.
     /// com/event/team_migration_started) event.
     TeamMigrationStarted,
+    /// Represents the slack
+    /// [`reconnect_url`](https://api.slack.com/event/reconnect_url)
+    /// event.
+    ReconnectUrl,
 }
 
 impl Decodable for Event {
@@ -502,6 +506,7 @@ impl Decodable for Event {
         "bot_changed" => Ok(Event::BotChanged { bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))) }),
         "accounts_changed" => Ok(Event::AccountsChanged),
         "team_migration_started" => Ok(Event::TeamMigrationStarted),
+        "reconnect_url" => Ok(Event::ReconnectUrl),
         _ => Err(d.error(&format!("Unknown Message type: {}", ty)))
         }
     }

--- a/src/api/events.rs
+++ b/src/api/events.rs
@@ -342,225 +342,167 @@ pub enum Event {
 impl Decodable for Event {
     fn decode<D: Decoder>(d: &mut D) -> Result<Event, D::Error> {
         let ty: String = try!(d.read_struct_field("type", 0, |d| Decodable::decode(d)));
-        if ty == "hello" {
-            return Ok(Event::Hello);
-        } else if ty == "message" {
-            Ok(Event::Message(try!(super::Message::decode(d))))
-        } else if ty == "user_typing" {
-            Ok(Event::UserTyping {
+        match ty.as_ref() {
+        "hello" => Ok(Event::Hello),
+        "message" => Ok(Event::Message(try!(super::Message::decode(d)))),
+        "user_typing" => Ok(Event::UserTyping {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "channel_marked" {
-            Ok(Event::ChannelMarked {
+            }),
+        "channel_marked" => Ok(Event::ChannelMarked {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "channel_created" {
-            Ok(Event::ChannelCreated { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "channel_joined" {
-            Ok(Event::ChannelJoined { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "channel_left" {
-            Ok(Event::ChannelLeft { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "channel_deleted" {
-            Ok(Event::ChannelDeleted { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "channel_rename" {
-            Ok(Event::ChannelRename { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "channel_archive" {
-            Ok(Event::ChannelArchive {
+            }),
+        "channel_created" => Ok(Event::ChannelCreated { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "channel_joined" => Ok(Event::ChannelJoined { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "channel_left" => Ok(Event::ChannelLeft { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "channel_deleted" => Ok(Event::ChannelDeleted { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "channel_rename" => Ok(Event::ChannelRename { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "channel_archive" => Ok(Event::ChannelArchive {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "channel_unarchive" {
-            Ok(Event::ChannelUnArchive {
+            }),
+        "channel_unarchive" => Ok(Event::ChannelUnArchive {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "channel_history_changed" {
-            Ok(Event::ChannelHistoryChanged {
+            }),
+        "channel_history_changed" => Ok(Event::ChannelHistoryChanged {
                 latest: try!(d.read_struct_field("latest", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "im_created" {
-            Ok(Event::ImCreated {
+            }),
+        "im_created" => Ok(Event::ImCreated {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "im_open" {
-            Ok(Event::ImOpen {
+            }),
+        "im_open" => Ok(Event::ImOpen {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "im_close" {
-            Ok(Event::ImClose {
+            }),
+        "im_close" => Ok(Event::ImClose {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "im_marked" {
-            Ok(Event::ImMarked {
+            }),
+        "im_marked" => Ok(Event::ImMarked {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "im_history_changed" {
-            Ok(Event::ImHistoryChanged {
+            }),
+        "im_history_changed" => Ok(Event::ImHistoryChanged {
                 latest: try!(d.read_struct_field("latest", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "group_joined" {
-            Ok(Event::GroupJoined { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "group_left" {
-            Ok(Event::GroupLeft { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "group_open" {
-            Ok(Event::GroupOpen {
+            }),
+        "group_joined" => Ok(Event::GroupJoined { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "group_left" => Ok(Event::GroupLeft { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "group_open" => Ok(Event::GroupOpen {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "group_close" {
-            Ok(Event::GroupClose {
+            }),
+        "group_close" => Ok(Event::GroupClose {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "group_archive" {
-            Ok(Event::GroupArchive { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "group_unarchive" {
-            Ok(Event::GroupUnArchive { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "group_rename" {
-            Ok(Event::GroupRename { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-        } else if ty == "group_marked" {
-            Ok(Event::GroupMarked {
+            }),
+        "group_archive" => Ok(Event::GroupArchive { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "group_unarchive" => Ok(Event::GroupUnArchive { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "group_rename" => Ok(Event::GroupRename { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+        "group_marked" => Ok(Event::GroupMarked {
                 channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "group_history_changed" {
-            Ok(Event::GroupHistoryChanged {
+            }),
+        "group_history_changed" => Ok(Event::GroupHistoryChanged {
                 latest: try!(d.read_struct_field("latest", 0, |d| Decodable::decode(d))),
                 ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "file_created" {
-            Ok(Event::FileCreated { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-        } else if ty == "file_shared" {
-            Ok(Event::FileShared { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-        } else if ty == "file_unshared" {
-            Ok(Event::FileUnShared { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-        } else if ty == "file_public" {
-            Ok(Event::FilePublic { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-        } else if ty == "file_private" {
-            Ok(Event::FilePrivate { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-        } else if ty == "file_change" {
-            Ok(Event::FileChange { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-        } else if ty == "file_deleted" {
-            Ok(Event::FileDeleted {
+            }),
+        "file_created" => Ok(Event::FileCreated { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+        "file_shared" => Ok(Event::FileShared { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+        "file_unshared" => Ok(Event::FileUnShared { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+        "file_public" => Ok(Event::FilePublic { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+        "file_private" => Ok(Event::FilePrivate { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+        "file_change" => Ok(Event::FileChange { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+        "file_deleted" => Ok(Event::FileDeleted {
                 file_id: try!(d.read_struct_field("file_id", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "file_comment_added" {
-            Ok(Event::FileCommentAdded {
+            }),
+        "file_comment_added" => Ok(Event::FileCommentAdded {
                 file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
                 comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "file_comment_edited" {
-            Ok(Event::FileCommentEdited {
+            }),
+        "file_comment_edited" => Ok(Event::FileCommentEdited {
                 file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
                 comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "file_comment_deleted" {
-            Ok(Event::FileCommentDeleted {
+            }),
+        "file_comment_deleted" => Ok(Event::FileCommentDeleted {
                 file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
                 comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "pin_added" {
-            Ok(Event::PinAdded {
+            }),
+        "pin_added" => Ok(Event::PinAdded {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel_id: try!(d.read_struct_field("channel_id", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "pin_removed" {
-            Ok(Event::PinRemoved {
+            }),
+        "pin_removed" => Ok(Event::PinRemoved {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 channel_id: try!(d.read_struct_field("channel_id", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 has_pins: try!(d.read_struct_field("has_pins", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "presence_change" {
-            Ok(Event::PresenceChange {
+            }),
+        "presence_change" => Ok(Event::PresenceChange {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 presence: try!(d.read_struct_field("presence", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "manual_presence_change" {
-            Ok(Event::ManualPresenceChange { presence: try!(d.read_struct_field("presence", 0, |d| Decodable::decode(d))) })
-        } else if ty == "pref_change" {
-            Ok(Event::PrefChange {
+            }),
+        "manual_presence_change" => Ok(Event::ManualPresenceChange { presence: try!(d.read_struct_field("presence", 0, |d| Decodable::decode(d))) }),
+        "pref_change" => Ok(Event::PrefChange {
                 name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
                 value: try!(d.read_struct_field("value", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "user_change" {
-            Ok(Event::UserChange { user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))) })
-        } else if ty == "team_join" {
-            Ok(Event::TeamJoin { user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))) })
-        } else if ty == "star_added" {
-            Ok(Event::StarAdded {
+            }),
+        "user_change" => Ok(Event::UserChange { user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))) }),
+        "team_join" => Ok(Event::TeamJoin { user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))) }),
+        "star_added" => Ok(Event::StarAdded {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "star_removed" {
-            Ok(Event::StarRemoved {
+            }),
+        "star_removed" => Ok(Event::StarRemoved {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "reaction_added" {
-            Ok(Event::ReactionAdded {
+            }),
+        "reaction_added" => Ok(Event::ReactionAdded {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "reaction_removed" {
-            Ok(Event::ReactionRemoved {
+            }),
+        "reaction_removed" => Ok(Event::ReactionRemoved {
                 user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
                 name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
                 item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "emoji_changed" {
-            Ok(Event::EmojiChanged { event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))) })
-        } else if ty == "commands_changed" {
-            Ok(Event::CommandsChanged { event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))) })
-        } else if ty == "team_plan_change" {
-            Ok(Event::TeamPlanChange { plan: try!(d.read_struct_field("plan", 0, |d| Decodable::decode(d))) })
-        } else if ty == "team_pref_change" {
-            Ok(Event::TeamPrefChange {
+            }),
+        "emoji_changed" => Ok(Event::EmojiChanged { event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))) }),
+        "commands_changed" => Ok(Event::CommandsChanged { event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))) }),
+        "team_plan_change" => Ok(Event::TeamPlanChange { plan: try!(d.read_struct_field("plan", 0, |d| Decodable::decode(d))) }),
+        "team_pref_change" => Ok(Event::TeamPrefChange {
                 name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
                 value: try!(d.read_struct_field("value", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "team_rename" {
-            Ok(Event::TeamRename { name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))) })
-        } else if ty == "team_domain_change" {
-            Ok(Event::TeamDomainChange {
+            }),
+        "team_rename" => Ok(Event::TeamRename { name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))) }),
+        "team_domain_change" => Ok(Event::TeamDomainChange {
                 url: try!(d.read_struct_field("url", 0, |d| Decodable::decode(d))),
                 domain: try!(d.read_struct_field("domain", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "email_domain_changeed" {
-            Ok(Event::EmailDomainChanged {
+            }),
+        "email_domain_changeed" => Ok(Event::EmailDomainChanged {
                 email_domain: try!(d.read_struct_field("email_domain", 0, |d| Decodable::decode(d))),
                 event_ts: try!(d.read_struct_field("event_ts", 0, |d| Decodable::decode(d))),
-            })
-        } else if ty == "bot_added" {
-            Ok(Event::BotAdded { bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))) })
-        } else if ty == "bot_changed" {
-            Ok(Event::BotChanged { bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))) })
-        } else if ty == "accounts_changed" {
-            Ok(Event::AccountsChanged)
-        } else if ty == "team_migration_started" {
-            Ok(Event::TeamMigrationStarted)
-        } else {
-            Err(d.error(&format!("Unknown Message type: {}", ty)))
+            }),
+        "bot_added" => Ok(Event::BotAdded { bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))) }),
+        "bot_changed" => Ok(Event::BotChanged { bot: try!(d.read_struct_field("bot", 0, |d| Decodable::decode(d))) }),
+        "accounts_changed" => Ok(Event::AccountsChanged),
+        "team_migration_started" => Ok(Event::TeamMigrationStarted),
+        _ => Err(d.error(&format!("Unknown Message type: {}", ty)))
         }
     }
 }

--- a/src/api/message_events.rs
+++ b/src/api/message_events.rs
@@ -227,175 +227,152 @@ impl Decodable for Message {
                 });
             }
             let ty = ty.unwrap();
-            if ty == "bot_message" {
-                Ok(Message::BotMessage {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    bot_id: try!(d.read_struct_field("bot_id", 0, |d| Decodable::decode(d))),
-                    username: try!(d.read_struct_field("username", 0, |d| Decodable::decode(d))),
-                    icons: try!(d.read_struct_field("icons", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "me_message" {
-                Ok(Message::MeMessage {
-                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "message_changed" {
-                Ok(Message::MessageChanged {
-                    hidden: try!(d.read_struct_field("hidden", 0, |d| Decodable::decode(d))),
-                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "message_deleted" {
-                Ok(Message::MessageDeleted {
-                    hidden: try!(d.read_struct_field("hidden", 0, |d| Decodable::decode(d))),
-                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    deleted_ts: try!(d.read_struct_field("deleted_ts", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel_join" {
-                Ok(Message::ChannelJoin {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    inviter: try!(d.read_struct_field("inviter", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel_leave" {
-                Ok(Message::ChannelLeave {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel_topic" {
-                Ok(Message::ChannelTopic {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    topic: try!(d.read_struct_field("topic", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel_purpose" {
-                Ok(Message::ChannelPurpose {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    purpose: try!(d.read_struct_field("purpose", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel_name" {
-                Ok(Message::ChannelName {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    old_name: try!(d.read_struct_field("old_name", 0, |d| Decodable::decode(d))),
-                    name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel_archive" {
-                Ok(Message::ChannelArchive {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    members: try!(d.read_struct_field("members", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel_unarchive" {
-                Ok(Message::ChannelUnarchive {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "group_join" {
-                Ok(Message::GroupJoin {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    inviter: try!(d.read_struct_field("inviter", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "group_leave" {
-                Ok(Message::GroupLeave {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "group_topic" {
-                Ok(Message::GroupTopic {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    topic: try!(d.read_struct_field("topic", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "group_purpose" {
-                Ok(Message::GroupPurpose {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    purpose: try!(d.read_struct_field("purpose", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "group_name" {
-                Ok(Message::GroupName {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    old_name: try!(d.read_struct_field("old_name", 0, |d| Decodable::decode(d))),
-                    name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "group_archive" {
-                Ok(Message::GroupArchive {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    members: try!(d.read_struct_field("members", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "group_unarchive" {
-                Ok(Message::GroupUnarchive {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "file_share" {
-                Ok(Message::FileShare {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    upload: try!(d.read_struct_field("upload", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "file_comment" {
-                Ok(Message::FileComment {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
-                    comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "file_mention" {
-                Ok(Message::FileMention {
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "pinned_item" {
-                Ok(Message::PinnedItem {
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    item_type: try!(d.read_struct_field("item_type", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
-                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    attachments: try!(d.read_struct_field("attachments", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "unpinned_item" {
-                Ok(Message::UnpinnedItem {
-                    user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
-                    item_type: try!(d.read_struct_field("item_type", 0, |d| Decodable::decode(d))),
-                    text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
-                    item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
-                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-                    ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
-                    attachments: try!(d.read_struct_field("attachments", 0, |d| Decodable::decode(d))),
-                })
-            } else {
-                Err(d.error(&format!("Unknown Message type: {}", ty)))
+            match ty.as_ref() {
+                "bot_message" => Ok(Message::BotMessage {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        bot_id: try!(d.read_struct_field("bot_id", 0, |d| Decodable::decode(d))),
+                        username: try!(d.read_struct_field("username", 0, |d| Decodable::decode(d))),
+                        icons: try!(d.read_struct_field("icons", 0, |d| Decodable::decode(d))),
+                    }),
+                "me_message" => Ok(Message::MeMessage {
+                        channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                    }),
+                "message_changed" => Ok(Message::MessageChanged {
+                        hidden: try!(d.read_struct_field("hidden", 0, |d| Decodable::decode(d))),
+                        channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d))),
+                    }),
+                "message_deleted" => Ok(Message::MessageDeleted {
+                        hidden: try!(d.read_struct_field("hidden", 0, |d| Decodable::decode(d))),
+                        channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        deleted_ts: try!(d.read_struct_field("deleted_ts", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel_join" => Ok(Message::ChannelJoin {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        inviter: try!(d.read_struct_field("inviter", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel_leave" => Ok(Message::ChannelLeave {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel_topic" => Ok(Message::ChannelTopic {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        topic: try!(d.read_struct_field("topic", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel_purpose" => Ok(Message::ChannelPurpose {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        purpose: try!(d.read_struct_field("purpose", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel_name" => Ok(Message::ChannelName {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        old_name: try!(d.read_struct_field("old_name", 0, |d| Decodable::decode(d))),
+                        name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel_archive" => Ok(Message::ChannelArchive {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        members: try!(d.read_struct_field("members", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel_unarchive" => Ok(Message::ChannelUnarchive {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    }),
+                "group_join" => Ok(Message::GroupJoin {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        inviter: try!(d.read_struct_field("inviter", 0, |d| Decodable::decode(d))),
+                    }),
+                "group_leave" => Ok(Message::GroupLeave {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "group_topic" => Ok(Message::GroupTopic {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        topic: try!(d.read_struct_field("topic", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "group_purpose" => Ok(Message::GroupPurpose {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        purpose: try!(d.read_struct_field("purpose", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "group_name" => Ok(Message::GroupName {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        old_name: try!(d.read_struct_field("old_name", 0, |d| Decodable::decode(d))),
+                        name: try!(d.read_struct_field("name", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                    }),
+                "group_archive" => Ok(Message::GroupArchive {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        members: try!(d.read_struct_field("members", 0, |d| Decodable::decode(d))),
+                    }),
+                "group_unarchive" => Ok(Message::GroupUnarchive {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    }),
+                "file_share" => Ok(Message::FileShare {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        upload: try!(d.read_struct_field("upload", 0, |d| Decodable::decode(d))),
+                    }),
+                "file_comment" => Ok(Message::FileComment {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                        comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
+                    }),
+                "file_mention" => Ok(Message::FileMention {
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                    }),
+                "pinned_item" => Ok(Message::PinnedItem {
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        item_type: try!(d.read_struct_field("item_type", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
+                        channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        attachments: try!(d.read_struct_field("attachments", 0, |d| Decodable::decode(d))),
+                    }),
+                "unpinned_item" => Ok(Message::UnpinnedItem {
+                        user: try!(d.read_struct_field("user", 0, |d| Decodable::decode(d))),
+                        item_type: try!(d.read_struct_field("item_type", 0, |d| Decodable::decode(d))),
+                        text: try!(d.read_struct_field("text", 0, |d| Decodable::decode(d))),
+                        item: try!(d.read_struct_field("item", 0, |d| Decodable::decode(d))),
+                        channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                        ts: try!(d.read_struct_field("ts", 0, |d| Decodable::decode(d))),
+                        attachments: try!(d.read_struct_field("attachments", 0, |d| Decodable::decode(d))),
+                    }),
+                _ => Err(d.error(&format!("Unknown Message type: {}", ty))),
             }
         })
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -237,20 +237,17 @@ impl Decodable for Item {
     fn decode<D: Decoder>(d: &mut D) -> Result<Item, D::Error> {
         d.read_struct("item", 0, |d| {
             let ty: String = try!(d.read_struct_field("type", 0, |d| Decodable::decode(d)));
-            if ty == "message" {
-                Ok(Item::Message {
+            match ty.as_ref() {
+                "message" => Ok(Item::Message {
                     channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
                     message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "file" {
-                Ok(Item::File { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-            } else if ty == "file_comment" {
-                Ok(Item::FileComment {
+                }),
+                "file" => Ok(Item::File { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+                "file_comment" => Ok(Item::FileComment {
                     file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
                     comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
-                })
-            } else {
-                Err(d.error(&format!("Unknown Item type: {}", ty)))
+                }),
+                _ => Err(d.error(&format!("Unknown Item type: {}", ty)))
             }
         })
     }
@@ -288,26 +285,20 @@ impl Decodable for StarredItem {
     fn decode<D: Decoder>(d: &mut D) -> Result<StarredItem, D::Error> {
         d.read_struct("item", 0, |d| {
             let ty: String = try!(d.read_struct_field("type", 0, |d| Decodable::decode(d)));
-            if ty == "message" {
-                Ok(StarredItem::Message {
-                    channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
-                    message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "file" {
-                Ok(StarredItem::File { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) })
-            } else if ty == "file_comment" {
-                Ok(StarredItem::FileComment {
-                    file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
-                    comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
-                })
-            } else if ty == "channel" {
-                Ok(StarredItem::Channel { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-            } else if ty == "group" {
-                Ok(StarredItem::Group { group: try!(d.read_struct_field("group", 0, |d| Decodable::decode(d))) })
-            } else if ty == "im" {
-                Ok(StarredItem::Im { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) })
-            } else {
-                Err(d.error(&format!("Unknown StarredItem type: {}", ty)))
+            match ty.as_ref() {
+                "message" => Ok(StarredItem::Message {
+                        channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))),
+                        message: try!(d.read_struct_field("message", 0, |d| Decodable::decode(d))),
+                    }),
+                "file" => Ok(StarredItem::File { file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))) }),
+                "file_comment" => Ok(StarredItem::FileComment {
+                        file: try!(d.read_struct_field("file", 0, |d| Decodable::decode(d))),
+                        comment: try!(d.read_struct_field("comment", 0, |d| Decodable::decode(d))),
+                    }),
+                "channel" => Ok(StarredItem::Channel { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+                "group" => Ok(StarredItem::Group { group: try!(d.read_struct_field("group", 0, |d| Decodable::decode(d))) }),
+                "im" => Ok(StarredItem::Im { channel: try!(d.read_struct_field("channel", 0, |d| Decodable::decode(d))) }),
+                _ => Err(d.error(&format!("Unknown StarredItem type: {}", ty))),
             }
         })
     }


### PR DESCRIPTION
My experimental bot started getting `reconnect_url` events, which show up as errors. I added an opaque `ReconnectUrl` type for them, as the [documentation](https://api.slack.com/events/reconnect_url) says they are "unsupported and experimental".

Also, I replaced the `if ty ==` references with a `match` pattern, which seemed more idiomatic.