### PR TITLE
Fix up dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,14 +26,10 @@ name = "slack"
 path = "src/lib.rs"
 
 [dependencies]
-websocket = "^0.14"
-# http library:
-hyper = "^0.7"
-# NOTE: coordinate these with hyper
-openssl = "^0.7"
-rustc-serialize = "^0.3"
-url = "^0.5"
+websocket = "0.14.0"
+hyper = "0.8.0"
+rustc-serialize = "0.3.18"
 
 [dev-dependencies]
-yup-hyper-mock = "^1.3.2"
-log = "^0.3.5"
+yup-hyper-mock = "1.3.2"
+log = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ path = "src/lib.rs"
 
 [dependencies]
 websocket = "0.14.0"
-hyper = "0.8.0"
+hyper = "0.7.2"
 rustc-serialize = "0.3.18"
 
 [dev-dependencies]
-yup-hyper-mock = "1.3.2"
+yup-hyper-mock = "=1.3.1"
 log = "0.3.5"

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -52,7 +52,7 @@ pub type ApiResult<T> = Result<T, Error>;
 /// params. Returns the response body string after checking it has "ok": true, or an Error
 fn make_api_call<'a, T: Decodable>(client: &hyper::Client, method: &str, custom_params: HashMap<&str, &'a str>) -> ApiResult<T> {
     let url_string = format!("https://slack.com/api/{}", method);
-    let mut url = try!(hyper::Url::parse(&url_string));
+    let mut url = try!(hyper::Url::parse(&url_string).map_err(|e| hyper::Error::Uri(e)));
 
     url.set_query_from_pairs(custom_params.into_iter());
 

--- a/src/api/oauth.rs
+++ b/src/api/oauth.rs
@@ -21,7 +21,7 @@ pub fn access(client: &hyper::Client, client_id: &str, client_secret: &str, code
         params.insert("redirect_uri", redirect_uri);
     }
 
-    let mut url = try!(hyper::Url::parse("https://slack.com/api/oauth.access"));
+    let mut url = try!(hyper::Url::parse("https://slack.com/api/oauth.access").map_err(|e| hyper::Error::Uri(e)));
     url.set_query_from_pairs(params.into_iter());
 
     let response = try!(client.get(url).send());

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use std::string::FromUtf8Error;
 
 use hyper;
 use websocket;
-use url;
 use rustc_serialize;
 
 /// slack::Error represents errors that can happen while using the RtmClient
@@ -18,7 +17,7 @@ pub enum Error {
     /// Error decoding websocket text frame Utf8
     Utf8(FromUtf8Error),
     /// Error parsing url
-    Url(url::ParseError),
+    Url(hyper::Error),
     /// Error decoding Json
     JsonDecode(rustc_serialize::json::DecoderError),
     /// Error parsing Json
@@ -33,19 +32,16 @@ pub enum Error {
 
 impl From<hyper::Error> for Error {
     fn from(err: hyper::Error) -> Error {
-        Error::Http(err)
+        match err {
+            hyper::Error::Uri(_) => Error::Url(err),
+            _ => Error::Http(err)
+        }
     }
 }
 
 impl From<websocket::result::WebSocketError> for Error {
     fn from(err: websocket::result::WebSocketError) -> Error {
         Error::WebSocket(err)
-    }
-}
-
-impl From<url::ParseError> for Error {
-    fn from(err: url::ParseError) -> Error {
-        Error::Url(err)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,9 +161,7 @@
 
 extern crate hyper;
 extern crate websocket;
-extern crate openssl;
 extern crate rustc_serialize;
-extern crate url;
 #[cfg(test)]
 #[macro_use]
 extern crate yup_hyper_mock;
@@ -189,7 +187,6 @@ use websocket::ws::sender::Sender as WsSenderTrait;
 use websocket::ws::receiver::Receiver as WsReceiverTrait;
 use websocket::client::Receiver as WsReceiver;
 use websocket::message::Type as WsType;
-use websocket::dataframe::DataFrame;
 use websocket::stream::WebSocketStream;
 
 pub type WsClient = Client<websocket::dataframe::DataFrame,
@@ -392,7 +389,7 @@ impl RtmClient {
         let start = try!(api::rtm::start(&client, &self.token, None, None));
 
         // websocket url
-        let wss_url = try!(hyper::Url::parse(&start.url));
+        let wss_url = try!(hyper::Url::parse(&start.url).map_err(|e| hyper::Error::Uri(e)));
 
         // update id hashmaps
         for ref channel in start.channels.iter() {


### PR DESCRIPTION
Two dependencies were unnecessary: `url` and `openssl`. 
- `url` was only used for the error type, which can be worked around by mapping the error to the appropriate `hyper` error type (which seems like a `hyper` API issue – may make a PR there to fix).
- `openssl` wasn't used at all. I didn't see the reason it was there, but I might be missing something.

Also cleans up some of the versions. Add patch numbers to versions and remove `^` from semver. Cargo already implicitly uses `^` for versions.

Will look at upgrading `hyper` to `0.8.0`. May also look at upgrading `websocket` to `0.15.1`, though that looks like a *much* larger change.