### PR TITLE
Bump hyper and websocket dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,11 @@ documentation = "https://bentheelder.github.io/slack-rs"
 description = "slack realtime messaging client: https://api.slack.com/bot-users"
 license = "Apache-2.0"
 
-[lib]
-name = "slack"
-path = "src/lib.rs"
-
 [dependencies]
-websocket = "0.14.0"
-hyper = "0.7.2"
+websocket = "0.15.2"
+hyper = "0.8.0"
 rustc-serialize = "0.3.18"
 
 [dev-dependencies]
-yup-hyper-mock = "=1.3.1"
+yup-hyper-mock = "1.3.2"
 log = "0.3.5"


### PR DESCRIPTION
Now that [`websocket` supports `hyper@0.8.0`](https://github.com/cyderize/rust-websocket/pull/71), we are safe to bump the remaining dependency versions.